### PR TITLE
Optimize the cryptpilot-convert.sh scrip

### DIFF
--- a/cryptpilot-convert.sh
+++ b/cryptpilot-convert.sh
@@ -484,11 +484,15 @@ step:update_rootfs_and_initrd() {
     fi
     # mount bind the /etc/resolv.conf
     proc::hook_exit "mountpoint -q ${rootfs_mount_point}/etc/resolv.conf && disk::umount_wait_busy ${rootfs_mount_point}/etc/resolv.conf"
-    mount --bind "$(realpath /etc/resolv.conf)" "${rootfs_mount_point}/etc/resolv.conf"
+    mv "${rootfs_mount_point}/etc/resolv.conf" "${rootfs_mount_point}/etc/resolv.conf.cryptpilot"
+    touch "${rootfs_mount_point}/etc/resolv.conf"
+    mount -o bind,ro "$(realpath /etc/resolv.conf)" "${rootfs_mount_point}/etc/resolv.conf"
     # mount bind the /etc/hosts
     proc::hook_exit "mountpoint -q ${rootfs_mount_point}/etc/hosts && disk::umount_wait_busy ${rootfs_mount_point}/etc/hosts"
-    mount --bind "$(realpath /etc/hosts)" "${rootfs_mount_point}/etc/hosts"
 
+    mv "${rootfs_mount_point}/etc/hosts" "${rootfs_mount_point}/etc/hosts.cryptpilot"
+    touch "${rootfs_mount_point}/etc/hosts"
+    mount -o bind,ro "$(realpath /etc/hosts)" "${rootfs_mount_point}/etc/hosts"
     log::info "Installing rpm packages"
     disk::install_rpm_on_rootfs "$rootfs_mount_point" "${packages[@]}"
 
@@ -591,7 +595,13 @@ EOF
     log::info "Cleaning up chroot environment"
 
     disk::umount_wait_busy "${rootfs_mount_point}/etc/hosts"
+    rm -f "${rootfs_mount_point}/etc/hosts"
+    mv "${rootfs_mount_point}/etc/hosts.cryptpilot" "${rootfs_mount_point}/etc/hosts"
+
     disk::umount_wait_busy "${rootfs_mount_point}/etc/resolv.conf"
+    rm -f "${rootfs_mount_point}/etc/resolv.conf"
+    mv "${rootfs_mount_point}/etc/resolv.conf.cryptpilot" "${rootfs_mount_point}/etc/resolv.conf"
+
     disk::umount_wait_busy "${rootfs_mount_point}/boot/efi"
     disk::umount_wait_busy "${rootfs_mount_point}/boot"
     disk::umount_wait_busy "${rootfs_mount_point}/sys"

--- a/cryptpilot-convert.sh
+++ b/cryptpilot-convert.sh
@@ -684,6 +684,8 @@ step::create_boot_part() {
     boot_part_end_sector=$((boot_start_sector + boot_size_in_sector - 1))
     log::info "Creating boot partition ($boot_start_sector ... $boot_part_end_sector sectors)"
     parted "$device" --script -- mkpart boot ext4 "${boot_start_sector}"s ${boot_part_end_sector}s
+    partprobe "$device"
+    udevadm settle --timeout=10
     boot_part="${device}p${boot_part_num}"
     [[ $boot_size_in_bytes == $(blockdev --getsize64 "$boot_part") ]] || log::error "Wrong size, something wrong in the script"
     log::info "Writing boot filesystem to partition"


### PR DESCRIPTION
1.Fix the issue of failed access to a partition after its creation
2.Fixed the issue where multiple kernels were installed in the system but the default kernel could not be detected
3.Fixed the issue of failed creation of AnolisOS-23.3-x86_64.qcow2 encrypted images
