### PR TITLE
show-reference-value: remove tdx prefix

### DIFF
--- a/cryptpilot.spec
+++ b/cryptpilot.spec
@@ -90,6 +90,8 @@ install -p -m 600 dist/etc/volumes/kbs.toml.template %{buildroot}/etc/cryptpilot
 install -p -m 600 dist/etc/volumes/kms.toml.template %{buildroot}/etc/cryptpilot/volumes/kms.toml.template
 install -p -m 600 dist/etc/volumes/oidc.toml.template %{buildroot}/etc/cryptpilot/volumes/oidc.toml.template
 install -p -m 600 dist/etc/volumes/exec.toml.template %{buildroot}/etc/cryptpilot/volumes/exec.toml.template
+install -d -p %{buildroot}/usr/share/cryptpilot
+install -p -m 644 dist/usr/share/cryptpilot/policy.rego %{buildroot}/usr/share/cryptpilot/policy.rego
 popd
 
 
@@ -122,6 +124,8 @@ rm -rf %{buildroot}
 %{dracut_dst}cryptpilot-fde-before-sysroot.service
 %{dracut_dst}cryptpilot-fde-after-sysroot.service
 %{dracut_dst}initrd-wait-network-online.service
+%dir /usr/share/cryptpilot
+/usr/share/cryptpilot/policy.rego
 
 
 %preun

--- a/dist/usr/share/cryptpilot/policy.rego
+++ b/dist/usr/share/cryptpilot/policy.rego
@@ -1,0 +1,34 @@
+package policy
+
+import future.keywords.every
+import future.keywords.if
+
+default allow := false
+
+allow if {
+	every k0, v0 in data.reference {
+		some k1
+		endswith(k1, k0)
+		match_value(v0, input[k1])
+	}
+}
+
+match_value(reference_value, input_value) if {
+	not is_array(reference_value)
+	input_value == reference_value
+}
+
+match_value(reference_value, input_value) if {
+	is_array(reference_value)
+	array_include(reference_value, input_value)
+}
+
+array_include(reference_value_array, _) if {
+	reference_value_array == []
+}
+
+array_include(reference_value_array, input_value) if {
+	reference_value_array != []
+	some i
+	reference_value_array[i] == input_value
+}

--- a/src/cmd/fde/show_reference_value.rs
+++ b/src/cmd/fde/show_reference_value.rs
@@ -34,17 +34,17 @@ impl super::super::Command for ShowReferenceValueCommand {
 
         let mut map = HashMap::new();
         map.insert(
-            format!("tdx.AA.eventlog.{AAEL_DOMAIN}.{OPERATION_NAME_LOAD_CONFIG}"),
+            format!("AA.eventlog.{AAEL_DOMAIN}.{OPERATION_NAME_LOAD_CONFIG}"),
             vec![hash_hex],
         );
         map.insert(
-            format!("tdx.AA.eventlog.{AAEL_DOMAIN}.{OPERATION_NAME_FDE_ROOTFS_HASH}"),
+            format!("AA.eventlog.{AAEL_DOMAIN}.{OPERATION_NAME_FDE_ROOTFS_HASH}"),
             vec![root_hash],
         );
 
         if matches!(self.stage, ShowReferenceValueStage::System) {
             map.insert(
-                format!("tdx.AA.eventlog.{AAEL_DOMAIN}.{OPERATION_NAME_INITRD_SWITCH_ROOT}"),
+                format!("AA.eventlog.{AAEL_DOMAIN}.{OPERATION_NAME_INITRD_SWITCH_ROOT}"),
                 vec!["{}".to_string()],
             );
         }


### PR DESCRIPTION
This commit remove the tee type prefix on the generated reference values. Also, this commit add the `.rego` file to the released rpm.