### PR TITLE
cryptpilot-convert: Add the parameter -b, --boot_part_size <size>  to…

### DIFF
--- a/cryptpilot-convert.sh
+++ b/cryptpilot-convert.sh
@@ -14,8 +14,8 @@ readonly PURPLE='\033[0;35m'
 readonly CYAN='\033[0;36m'
 readonly NC='\033[0m' # No Color
 
-# the size is currently fixed with 512MB
-readonly BOOT_PART_SIZE="512M"
+# the size is currently fixed with 512MB,it can be adjusted by passing in the parameter -b size
+BOOT_PART_SIZE="512M"
 # alignment to 2048 sectors creating a new partition
 readonly PARTITION_SECTOR_ALIGNMENT=2048
 
@@ -219,6 +219,7 @@ proc::print_help_and_exit() {
     echo "                                                          search for the rootfs partition by label='root' and fail if not found. You can override this"
     echo "                                                          behavior by specifying the partition number."
     echo "      --package <rpm_package>                             Specify an RPM package name or path to the RPM file to install in to the disk before"
+    echo "  -b, --boot_part_size <size>                             Instead of using the default partition size(512MB), specify the size of the boot partition"
     echo "                                                          converting. This can be specified multiple times."
     echo "  -h, --help                                              Show this help message and exit."
     exit "$1"
@@ -384,7 +385,7 @@ step::extract_boot_part_from_rootfs() {
     boot_file_path="${workdir}/boot.img"
 
     log::info "Creating boot partition image of size $BOOT_PART_SIZE"
-    fallocate -l $BOOT_PART_SIZE "$boot_file_path"
+    fallocate -l "$BOOT_PART_SIZE" "$boot_file_path"
     yes | mkfs.ext4 "$boot_file_path"
     local boot_mount_point=${workdir}/boot
     mkdir -p "$boot_mount_point"
@@ -840,6 +841,10 @@ main() {
             ;;
         --package)
             packages+=("$2")
+            shift 2
+            ;;
+        -b | --boot_part_size)
+            BOOT_PART_SIZE=("$2")
             shift 2
             ;;
         -h | --help)


### PR DESCRIPTION
… adjust the size of the boot partition

The default size of the boot partition is set to 512M. In some cases, this size cannot meet the requirements and a larger partition is needed