### PR TITLE
fde: add DM_UDEV_DISABLE_OTHER_RULES_FLAG to hide intermediate cryptpilot devices

### DIFF
--- a/dist/usr/lib/udev/rules.d/12-cryptpilot-hide-intermediate-devices.rules
+++ b/dist/usr/lib/udev/rules.d/12-cryptpilot-hide-intermediate-devices.rules
@@ -1,13 +1,15 @@
 # Rules for intermediate devices created by cryptpilot
 #
-# This rule should be placed after /usr/lib/udev/rules.d/10-dm.rules, /usr/lib/udev/rules.d/11-dm-lvm.rules and before /usr/lib/udev/rules.d/13-dm-disk.rules
+# This rule should be placed after /usr/lib/udev/rules.d/10-dm.rules, /usr/lib/udev/rules.d/11-dm-lvm.rules and before /usr/lib/udev/rules.d/13-dm-disk.rules, /etc/udev/rules.d/61-persistent-storage.rules
 
 # Prevent /dev/system/rootfs from creating /dev/disk/by-uuid/... symlinks
 ENV{DM_VG_NAME}=="system", ENV{DM_LV_NAME}=="rootfs", \
     ENV{UDISKS_IGNORE}="1", \
-    ENV{DM_UDEV_DISABLE_DISK_RULES_FLAG}="1"
+    ENV{DM_UDEV_DISABLE_DISK_RULES_FLAG}="1", \
+    ENV{DM_UDEV_DISABLE_OTHER_RULES_FLAG}="1"
 
 # Prevent /dev/mapper/rootfs_decrypted from creating /dev/disk/by-uuid/... symlinks
 ENV{DM_NAME}=="rootfs_decrypted", \
     ENV{UDISKS_IGNORE}="1", \
-    ENV{DM_UDEV_DISABLE_DISK_RULES_FLAG}="1"
+    ENV{DM_UDEV_DISABLE_DISK_RULES_FLAG}="1", \
+    ENV{DM_UDEV_DISABLE_OTHER_RULES_FLAG}="1"


### PR DESCRIPTION
Extend udev rules for cryptpilot intermediate devices (/dev/system/rootfs and /dev/mapper/rootfs_decrypted) by setting DM_UDEV_DISABLE_OTHER_RULES_FLAG=1 in addition to DM_UDEV_DISABLE_DISK_RULES_FLAG=1. This ensures that not only disk-related rules (like 60-persistent-storage.rules), but also other external udev rules (e.g., UDisks, auto-mounters) skip processing these devices.

Updated comment to clarify rule ordering dependency, especially with /etc/udev/rules.d/61-persistent-storage.rules, to prevent unwanted symlinks or side effects.

This improves device isolation and avoids potential conflicts during boot or device enumeration.