### PR TITLE
fix: clarify IMDS reachability error instead of "not an ECS instance"

### DIFF
--- a/cryptpilot-core/src/vendor/aliyun/mod.rs
+++ b/cryptpilot-core/src/vendor/aliyun/mod.rs
@@ -1,17 +1,32 @@
 use std::time::Duration;
 
+use anyhow::{bail, Context as _, Result};
 use tokio::net::TcpStream;
 
 pub mod cloudinit;
 pub mod ntp;
 
-pub async fn check_is_aliyun_ecs() -> bool {
-    matches!(
-        tokio::time::timeout(
-            Duration::from_secs(5),
-            TcpStream::connect(("100.100.100.200", 80)),
-        )
-        .await,
-        Ok(Ok(_))
+/// Check whether the current host is an Aliyun ECS instance by probing the
+/// IMDS endpoint (100.100.100.200:80).  Returns `Ok(())` when the endpoint is
+/// reachable, or a descriptive error explaining *why* the check failed so that
+/// callers can produce actionable log messages instead of the generic
+/// "not an ECS instance" phrasing.
+pub async fn check_is_aliyun_ecs() -> Result<()> {
+    match tokio::time::timeout(
+        Duration::from_secs(5),
+        TcpStream::connect(("100.100.100.200", 80)),
     )
+    .await
+    {
+        Err(_elapsed) => bail!(
+            "Timed out connecting to Aliyun IMDS endpoint (100.100.100.200:80). \
+             The instance may not be an Aliyun ECS, or IMDS may be disabled / \
+             blocked by a security-group rule."
+        ),
+        Ok(Err(e)) => Err(e).context(
+            "Failed to connect to Aliyun IMDS endpoint (100.100.100.200:80). \
+             The instance may not be an Aliyun ECS, or IMDS may be disabled.",
+        ),
+        Ok(Ok(_)) => Ok(()),
+    }
 }

--- a/cryptpilot-fde/src/cmd/boot_service/time_sync.rs
+++ b/cryptpilot-fde/src/cmd/boot_service/time_sync.rs
@@ -1,9 +1,8 @@
 use anyhow::{Context, Result};
 
 pub async fn sync_time_to_system() -> Result<()> {
-    let is_ecs = cryptpilot::vendor::aliyun::check_is_aliyun_ecs().await;
-    if !is_ecs {
-        tracing::debug!("Not a Aliyun ECS instance, skip syncing system time");
+    if let Err(e) = cryptpilot::vendor::aliyun::check_is_aliyun_ecs().await {
+        tracing::debug!("Aliyun IMDS not reachable, skip syncing system time: {e:#}");
         return Ok(());
     } else {
         tracing::info!("Aliyun ECS instance detected, sync system time now");
@@ -39,8 +38,10 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
     async fn test_time() -> Result<()> {
-        let is_ecs = cryptpilot::vendor::aliyun::check_is_aliyun_ecs().await;
-        if !is_ecs {
+        if cryptpilot::vendor::aliyun::check_is_aliyun_ecs()
+            .await
+            .is_err()
+        {
             /* Skip */
             return Ok(());
         } else {

--- a/cryptpilot-fde/src/config/cloud_init.rs
+++ b/cryptpilot-fde/src/config/cloud_init.rs
@@ -49,14 +49,15 @@ impl super::FdeConfigSource for CloudInitConfigSource {
     }
 
     async fn get_fde_config_bundle(&self) -> Result<FdeConfigBundle> {
-        let is_ecs = cryptpilot::vendor::aliyun::check_is_aliyun_ecs().await;
-        if !is_ecs {
-            bail!("Not a Aliyun ECS instance, skip fetching config from cloud-init user data");
-        } else {
-            let user_data =
-                cryptpilot::vendor::aliyun::cloudinit::get_aliyun_ecs_cloudinit_user_data().await?;
-            Self::parse_from_user_data(&user_data)
-        }
+        cryptpilot::vendor::aliyun::check_is_aliyun_ecs()
+            .await
+            .context(
+                "Aliyun IMDS is not reachable, skip fetching config from cloud-init user data",
+            )?;
+
+        let user_data =
+            cryptpilot::vendor::aliyun::cloudinit::get_aliyun_ecs_cloudinit_user_data().await?;
+        Self::parse_from_user_data(&user_data)
     }
 }
 


### PR DESCRIPTION
## Problem

`check_is_aliyun_ecs()` probes the IMDS endpoint (`100.100.100.200:80`) via TCP to determine whether the host is an Aliyun ECS instance. When the TCP connection fails (timeout or connection refused), the original code returned `false` and callers emitted the misleading log line **"Not a Aliyun ECS instance"**.

Users misread this as a machine-type mismatch, when the real cause is typically that the IMDS endpoint is unreachable — e.g. blocked by a security-group rule or IMDS is disabled on the instance.

## Changes

- **`check_is_aliyun_ecs()`**: return type changed from `bool` to `Result<()>`. Timeout and connection-refused cases now produce distinct error messages that name the exact endpoint and suggest probable causes.
- **`cloud_init.rs`**: propagates the error via `.context(...)` so the full log chain is actionable.
- **`time_sync.rs`**: updated to the new API; the debug log now prints the actual IMDS error instead of the generic "not an ECS instance" string.

## Before / After

**Before:**
```
Failed to load config from cloud-init: Not a Aliyun ECS instance, skip fetching config from cloud-init user data
```

**After:**
```
Failed to load config from cloud-init: Aliyun IMDS is not reachable, skip fetching config from cloud-init user data

Caused by:
    Timed out connecting to Aliyun IMDS endpoint (100.100.100.200:80). The instance may not be an Aliyun ECS, or IMDS may be disabled / blocked by a security-group rule.
```