### PR TITLE
fix(disk-persistent): handle dirty COW device in dm-snapshot setup

### DIFF
--- a/cryptpilot-core/src/fs/blkid.rs
+++ b/cryptpilot-core/src/fs/blkid.rs
@@ -1,0 +1,110 @@
+use std::path::Path;
+
+use anyhow::{bail, Context as _, Result};
+use tokio::process::Command;
+
+use crate::fs::cmd::CheckCommandOutput;
+
+/// Result of probing a block device with `blkid -p`.
+#[derive(Debug, Clone)]
+pub enum BlkidProbeResult {
+    /// No filesystem signatures detected on the device.
+    NoSignatures,
+    /// A known filesystem or partition type was detected.
+    KnownSignature {
+        /// Filesystem type from `TYPE="..."`, if present.
+        fs_type: Option<String>,
+        /// Partition table type from `PTTYPE="..."`, if present.
+        pt_type: Option<String>,
+    },
+}
+
+impl BlkidProbeResult {
+    /// Returns `true` if no signature was detected.
+    pub fn is_clean(&self) -> bool {
+        matches!(self, Self::NoSignatures)
+    }
+
+    /// Returns `true` if the device contains dm-snapshot COW metadata.
+    pub fn is_dm_snapshot_cow(&self) -> bool {
+        match self {
+            Self::KnownSignature {
+                fs_type: Some(fs_type),
+                ..
+            } => fs_type.contains("DM_snapshot_cow"),
+            _ => false,
+        }
+    }
+}
+
+/// Probe a block device using `blkid -p` and parse the output.
+///
+/// Exit codes:
+/// - `0`: signatures detected → `KnownSignature`
+/// - `2`: no signatures detected → `NoSignatures`
+/// - Other: returns an error
+///
+/// Note: `PTTYPE="atari"` is a known false positive on blank devices
+/// (see <https://bugs.launchpad.net/ubuntu/+source/util-linux/+bug/2015355>)
+/// and is treated as `NoSignatures`.
+pub async fn probe_device(device_path: &Path) -> Result<BlkidProbeResult> {
+    Command::new("blkid")
+        .arg("-p")
+        .arg(device_path)
+        .env("LC_ALL", "C")
+        .run_with_status_checker(|code, stdout, _stderr| {
+            match code {
+                0 => {
+                    let output = String::from_utf8_lossy(&stdout);
+                    let trimmed = output.trim().to_string();
+
+                    // Parse TYPE="..."
+                    let fs_type = parse_blkid_field(&trimmed, "TYPE");
+                    // Parse PTTYPE="..."
+                    let pt_type = parse_blkid_field(&trimmed, "PTTYPE");
+
+                    // Treat atari partition table as no signature (known false positive)
+                    // See: https://bugs.launchpad.net/ubuntu/+source/util-linux/+bug/2015355
+                    if pt_type.as_deref() == Some("atari") && fs_type.is_none() {
+                        tracing::info!(
+                            "blkid probe on {device_path:?}: PTTYPE=\"atari\" (known false positive), treating as no signature"
+                        );
+                        return Ok(BlkidProbeResult::NoSignatures);
+                    }
+
+                    tracing::info!(
+                        "blkid probe on {device_path:?}: fs_type={fs_type:?}, pt_type={pt_type:?}"
+                    );
+
+                    Ok(BlkidProbeResult::KnownSignature { fs_type, pt_type })
+                }
+                2 => {
+                    // blkid exit code 2 = no signatures found
+                    Ok(BlkidProbeResult::NoSignatures)
+                }
+                _ => {
+                    let stdout = String::from_utf8_lossy(&stdout);
+                    let stderr = String::from_utf8_lossy(&_stderr);
+                    bail!(
+                        "blkid probe failed with exit code {}: stdout='{}', stderr='{}'",
+                        code,
+                        stdout.trim(),
+                        stderr.trim()
+                    )
+                }
+            }
+        })
+        .await
+        .context("Failed to execute blkid probe")
+}
+
+/// Extract a field value from blkid output.
+///
+/// blkid outputs key-value pairs like: `TYPE="ext4" PTTYPE="dos"`
+fn parse_blkid_field(output: &str, key: &str) -> Option<String> {
+    let pattern = format!("{}=\"", key);
+    let start = output.find(&pattern)? + pattern.len();
+    let rest = &output[start..];
+    let end = rest.find('"')?;
+    Some(rest[..end].to_string())
+}

--- a/cryptpilot-core/src/fs/mkfs.rs
+++ b/cryptpilot-core/src/fs/mkfs.rs
@@ -12,7 +12,7 @@ use tokio::{
 };
 
 use crate::{
-    fs::{block::dummy::DummyDevice, cmd::CheckCommandOutput as _},
+    fs::{blkid::BlkidProbeResult, block::dummy::DummyDevice, cmd::CheckCommandOutput as _},
     types::{IntegrityType, MakeFsType},
 };
 
@@ -197,64 +197,32 @@ pub async fn force_mkfs(
 /// - If `fs_hint` is `Some`, and the expected filesystem is not detected, returns an error.
 /// - If `fs_hint` is `None`, returns `true` if something detected on the device.
 pub async fn has_valuable_data(device_path: &Path, fs_hint: Option<MakeFsType>) -> Result<bool> {
-    Command::new("blkid")
-        .arg("-p")
-        .arg(device_path)
-        .env("LC_ALL", "C")
-        .run_with_status_checker(|code, stdout, stderr| {
-            match code {
-                0 => {
-                    let output = String::from_utf8_lossy(&stdout);
+    let probe = crate::fs::blkid::probe_device(device_path).await?;
 
-                    match fs_hint {
-                        Some(expected_fs) => {
-                            let expected_str = match expected_fs {
-                                MakeFsType::Swap => "swap",
-                                MakeFsType::Ext4 => "ext4",
-                                MakeFsType::Xfs => "xfs",
-                                MakeFsType::Vfat => "vfat",
-                            };
+    match (probe, fs_hint) {
+        (BlkidProbeResult::NoSignatures, _) => Ok(false),
+        (BlkidProbeResult::KnownSignature { fs_type, .. }, Some(expected_fs)) => {
+            let expected_str = match expected_fs {
+                MakeFsType::Swap => "swap",
+                MakeFsType::Ext4 => "ext4",
+                MakeFsType::Xfs => "xfs",
+                MakeFsType::Vfat => "vfat",
+            };
 
-                            if output.contains(&format!("TYPE=\"{}\"", expected_str)) {
-                                Ok(true)
-                            } else {
-                                // Something else detected (may have partition table, unknown FS, etc.)
-                                bail!(
-                                    "Something else on {device_path:?} is detected, but expected '{expected_str}', found blkid output '{}'",
-                                    output.trim()
-                                );
-                            }
-                        }
-                        None => {
-                            // Check if it's mistakenly identified as PTTYPE="atari" partition table.
-                            // See: https://bugs.launchpad.net/ubuntu/+source/util-linux/+bug/2015355
-                            if output.contains("PTTYPE=\"atari\"") {
-                                tracing::debug!("Found PTTYPE=\"atari\" partition table on {device_path:?}, treating as no valuable data");
-                                Ok(false)
-                            }else{
-                                // Log which one was found (for debug)
-                                tracing::debug!("Found filesystem signature on {device_path:?}, blkid output: {}", output.trim());
-                                Ok(true)
-                            }
-                        }
-                    }
-                }
-                2 => {
-                    // No signatures found
-                    Ok(false)
-                }
-                _ => {
-                    let stdout = String::from_utf8_lossy(&stdout);
-                    let stderr = String::from_utf8_lossy(&stderr);
-                    bail!(
-                        "blkid failed with exit code {}: stdout='{}', stderr='{}'",
-                        code,
-                        stdout.trim(),
-                        stderr.trim()
-                    );
-                }
+            if fs_type.as_deref() == Some(expected_str) {
+                Ok(true)
+            } else {
+                // Something else detected (may have partition table, unknown FS, etc.)
+                bail!(
+                    "Something else on {device_path:?} is detected (found {fs_type:?}), but expected '{expected_str}'"
+                );
             }
-        })
-        .await
-        .context("Failed to detect filesystem signatures using blkid")
+        }
+        (probe @ BlkidProbeResult::KnownSignature { .. }, None) => {
+            tracing::info!(
+                "Found filesystem signature on {device_path:?}, probe result: {probe:?}"
+            );
+            Ok(true)
+        }
+    }
 }

--- a/cryptpilot-core/src/fs/mod.rs
+++ b/cryptpilot-core/src/fs/mod.rs
@@ -1,3 +1,4 @@
+pub mod blkid;
 pub mod block;
 pub mod cmd;
 pub mod kernel_module;

--- a/cryptpilot-fde/src/cmd/boot_service/stage/before_sysroot.rs
+++ b/cryptpilot-fde/src/cmd/boot_service/stage/before_sysroot.rs
@@ -429,6 +429,25 @@ async fn create_zram_cow_device() -> Result<PathBuf> {
     Ok(PathBuf::from(format!("/dev/zram{}", zram_id)))
 }
 
+/// Wipe a device by writing zeros using tokio async I/O.
+/// Writes 4KB megabytes of zeros to the device.
+async fn wipe_cow_device_header_async(device_path: &Path) -> Result<(), anyhow::Error> {
+    use tokio::fs::OpenOptions;
+
+    let mut file = OpenOptions::new()
+        .write(true)
+        .open(device_path)
+        .await
+        .context("Failed to open device for wiping")?;
+
+    file.write_all(&[0u8; 4096]).await?;
+
+    // Final sync to ensure everything is written
+    file.sync_all().await?;
+
+    Ok(())
+}
+
 async fn setup_dm_snapshot_device_chain(
     rootfs_device: &Path,
     cow_device: &Path,
@@ -437,6 +456,7 @@ async fn setup_dm_snapshot_device_chain(
     tracing::info!(
         ?rootfs_device,
         ?cow_device,
+        persistent,
         "Building dm-snapshot device chain"
     );
 
@@ -471,6 +491,41 @@ async fn setup_dm_snapshot_device_chain(
         .run()
         .await
         .context("Failed to create dm-linear device")?;
+
+    if !persistent {
+        // Non-persistent mode: directly wipe the COW device, no need to probe
+        tracing::info!("Non-persistent mode: wiping COW device");
+        wipe_cow_device_header_async(cow_device)
+            .await
+            .context("Failed to wipe COW device")?;
+    } else {
+        // Persistent mode: probe COW device to determine safe action
+        tracing::info!("Persistent mode: probing COW device state");
+        let probe = cryptpilot::fs::blkid::probe_device(cow_device).await?;
+
+        match probe {
+            cryptpilot::fs::blkid::BlkidProbeResult::NoSignatures => {
+                // Clean device, safe to wipe
+                tracing::info!("COW device is clean, wiping");
+                wipe_cow_device_header_async(cow_device)
+                    .await
+                    .context("Failed to wipe COW device")?;
+            }
+            cryptpilot::fs::blkid::BlkidProbeResult::KnownSignature { .. }
+                if probe.is_dm_snapshot_cow() =>
+            {
+                // No need to wipe and just use the metadata header
+                tracing::info!("COW device has dm-snapshot metadata, using it");
+            }
+            cryptpilot::fs::blkid::BlkidProbeResult::KnownSignature { fs_type, pt_type } => {
+                // Some other filesystem/partition signature detected — protect user data
+                bail!(
+                    "COW device has valuable data (fs_type={fs_type:?}, pt_type={pt_type:?}), \
+                     cannot overwrite in persistent mode"
+                );
+            }
+        }
+    }
 
     // Create dm-snapshot device
     tracing::info!("Creating dm-snapshot device");


### PR DESCRIPTION
CI failure observed on first boot:

    device-mapper: persistent snapshot: Invalid or corrupt snapshot
    device-mapper: table: 252:7: snapshot: Failed to read snapshot metadata
    device-mapper: ioctl: error adding target to table
    cmd: LC_ALL="C" "dmsetup" "create" "rootfs" "--table"          "0 41356504 snapshot /dev/mapper/rootfs_extended /dev/mapper/delta PO 16"

Root cause: the COW device (/dev/mapper/delta) contains stale data from a previous session, causing dm-snapshot to reject it as corrupt.

Fix: add blkid probe module (cryptpilot::fs::blkid) to detect filesystem signatures on the COW device before creating dm-snapshot.
- Persistent mode: probe determines whether it is safe to wipe (no signatures or corrupted dm-snapshot metadata) or bail out to protect user data.
- Non-persistent mode: skip probing and wipe directly.

Also refactor has_valuable_data in mkfs.rs to use the new probe_device function, deduplicating blkid logic.