### PR TITLE
docs(crypt): add encryption algorithms and kernel config requirements

### DIFF
--- a/cryptpilot-crypt/README.md
+++ b/cryptpilot-crypt/README.md
@@ -12,6 +12,32 @@
 - **Integrity Protection**: Optional dm-integrity for data authenticity
 - **Flexible File Systems**: Support for ext4, xfs, vfat, swap
 
+## Encryption and Integrity
+
+cryptpilot-crypt uses the following algorithms for LUKS2 volumes:
+
+- **Encryption**: `aes-xts-plain64`
+- **Integrity** (when enabled): `hmac-sha256`
+
+### Kernel Configuration Requirements
+
+The following kernel config options are always required for encryption:
+
+```
+CONFIG_CRYPTO_AES=y
+CONFIG_CRYPTO_AES_NI_INTEL=y
+CONFIG_CRYPTO_XTS=y
+```
+
+When `integrity = true` is enabled, the following additional options are required:
+
+```
+CONFIG_DM_INTEGRITY=y
+CONFIG_DM_BUFIO=y
+CONFIG_CRYPTO_HMAC=y
+CONFIG_AS_SHA256_NI=y
+```
+
 ## Installation
 
 Install from the [latest release](https://github.com/openanolis/cryptpilot/releases):

--- a/cryptpilot-crypt/README_zh.md
+++ b/cryptpilot-crypt/README_zh.md
@@ -12,6 +12,32 @@
 - **完整性保护**：可选的 dm-integrity 数据真实性保护
 - **灵活的文件系统**：支持 ext4、xfs、vfat、swap
 
+## 加密与完整性
+
+cryptpilot-crypt 使用以下算法进行 LUKS2 卷加密：
+
+- **加密算法**：`aes-xts-plain64`
+- **完整性算法**（启用时）：`hmac-sha256`
+
+### 内核配置要求
+
+以下内核配置选项始终需要（用于加密功能）：
+
+```
+CONFIG_CRYPTO_AES=y
+CONFIG_CRYPTO_AES_NI_INTEL=y
+CONFIG_CRYPTO_XTS=y
+```
+
+当启用 `integrity = true` 时，还需要以下额外选项：
+
+```
+CONFIG_DM_INTEGRITY=y
+CONFIG_DM_BUFIO=y
+CONFIG_CRYPTO_HMAC=y
+CONFIG_AS_SHA256_NI=y
+```
+
 ## 安装
 
 从[最新发布版本](https://github.com/openanolis/cryptpilot/releases)安装：


### PR DESCRIPTION
Document the algorithms used for LUKS2 volumes:
- Encryption: aes-xts-plain64 (always required)
- Integrity: hmac-sha256 (when integrity=true)

Split kernel config requirements into two sections: always-required for encryption, and additional options needed only when integrity=true.