### PR TITLE
feat(core,crypt): add fs stress tests and improve mkfs reliability

### DIFF
--- a/cryptpilot-core/src/fs/block/dummy.rs
+++ b/cryptpilot-core/src/fs/block/dummy.rs
@@ -96,7 +96,7 @@ impl Drop for DummyDevice {
 const LOOP_SET_BLOCK_SIZE: u64 = 0x4C09;
 
 fn loop_device_set_block_size(ld: &LoopDevice, block_size: u64) -> Result<()> {
-    let _ = unsafe {
+    let _: i32 = unsafe {
         nix::errno::Errno::result(libc::ioctl(ld.as_raw_fd(), LOOP_SET_BLOCK_SIZE, block_size))
     }
     .context("Failed to LOOP_SET_BLOCK_SIZE")?;

--- a/cryptpilot-core/src/fs/mkfs.rs
+++ b/cryptpilot-core/src/fs/mkfs.rs
@@ -35,15 +35,18 @@ impl MakeFs for NormalMakeFs {
         fs_type: MakeFsType,
     ) -> Result<()> {
         // Use mkfs commands directly instead of systemd-makefs
-        let (mkfs_cmd, force_arg) = match fs_type {
-            MakeFsType::Swap => ("mkswap", "-f"), // mkswap uses -f for force
-            MakeFsType::Ext4 => ("mkfs.ext4", "-F"), // mkfs.ext4 uses -F for force
-            MakeFsType::Xfs => ("mkfs.xfs", "-f"), // mkfs.xfs uses -f for force
-            MakeFsType::Vfat => ("mkfs.vfat", "-I"), // mkfs.vfat uses -I to force formatting
+        let (mkfs_cmd, args): (_, &[&str]) = match fs_type {
+            MakeFsType::Swap => ("mkswap", &["-f"]), // mkswap uses -f for force
+            MakeFsType::Ext4 => (
+                "mkfs.ext4",
+                &["-F", "-E", "lazy_itable_init=0,lazy_journal_init=0"],
+            ), // mkfs.ext4 uses -F for force
+            MakeFsType::Xfs => ("mkfs.xfs", &["-f"]), // mkfs.xfs uses -f for force
+            MakeFsType::Vfat => ("mkfs.vfat", &["-I"]), // mkfs.vfat uses -I to force formatting
         };
 
         Command::new(mkfs_cmd)
-            .arg(force_arg)
+            .args(args)
             .arg(device_path.as_ref())
             .run()
             .await?;
@@ -64,7 +67,11 @@ impl MakeFs for IntegrityNoWipeMakeFs {
             (file.get_block_device_size()?, file.get_size_of_block()?)
         };
 
-        tracing::info!("Setup dummy device with {device_size} bytes size for recording");
+        tracing::info!(
+            device_size,
+            block_size,
+            "Setup dummy device for blktrace recording operations"
+        );
 
         // Create a dummy device same size as the real one
         let dummy_device = DummyDevice::setup_on_tmpfs_with_block_size(device_size, block_size)
@@ -140,12 +147,16 @@ impl MakeFs for IntegrityNoWipeMakeFs {
             let mut real_device_file = File::options()
                 .write(true)
                 .read(true)
-                // .custom_flags(libc::O_DIRECT)
+                // .custom_flags(libc::O_DIRECT) // we disable here since O_DIRECT is not work on loop
                 .open(&device_path)
                 .await?;
             let mut buf = vec![0; page_size as usize];
             for i in rw_positions {
                 let offset = i * page_size;
+                tracing::trace!(
+                    "migrating page {i} at offset {offset} with {} bytes",
+                    buf.len()
+                );
                 dummy_device_file
                     .seek(std::io::SeekFrom::Start(offset))
                     .await?;

--- a/cryptpilot-core/src/types.rs
+++ b/cryptpilot-core/src/types.rs
@@ -32,10 +32,27 @@ impl From<Vec<u8>> for Passphrase {
     }
 }
 
+/// Data integrity verification type for LUKS2 encrypted volumes.
+///
+/// Corresponds to the `--integrity` option in cryptsetup. When enabled,
+/// integrity verification is performed on every I/O to prevent silent
+/// data corruption.
 #[derive(Debug, Clone, Copy)]
 pub enum IntegrityType {
+    /// Do not enable integrity verification.
     None,
+    /// Enable integrity verification with journaling (default).
+    ///
+    /// Provides stronger data consistency guarantees and allows recovery
+    /// via the journal after a crash. Suitable for persistent storage. 
+    /// But it will write data twice, one for journal and one for actual
+    /// data area.
     Journal,
+    /// Enable integrity verification without journaling.
+    ///
+    /// Lower write overhead compared to `Journal`, but does not support
+    /// crash recovery. Suitable for performance-sensitive scenarios where
+    /// some consistency risk is acceptable.
     NoJournal,
 }
 

--- a/cryptpilot-core/src/types.rs
+++ b/cryptpilot-core/src/types.rs
@@ -44,7 +44,7 @@ pub enum IntegrityType {
     /// Enable integrity verification with journaling (default).
     ///
     /// Provides stronger data consistency guarantees and allows recovery
-    /// via the journal after a crash. Suitable for persistent storage. 
+    /// via the journal after a crash. Suitable for persistent storage.
     /// But it will write data twice, one for journal and one for actual
     /// data area.
     Journal,

--- a/cryptpilot-crypt/tests/volume_tests.rs
+++ b/cryptpilot-crypt/tests/volume_tests.rs
@@ -3,7 +3,10 @@
 
 #![allow(unused_macros)]
 
-use std::{future::Future, path::PathBuf};
+use std::{
+    future::Future,
+    path::{Path, PathBuf},
+};
 
 use cryptpilot_crypt::{
     async_defer,
@@ -278,6 +281,13 @@ pub async fn run_test_on_volume(config_str: &str, use_external_suite: bool) -> R
             )
             .await?;
 
+            // Open and test fs stress
+            open_and_mount(&volume_config, |_, mount_dir: PathBuf| async move {
+                run_fs_stress(&mount_dir, PARALLEL_FS_STRESS).await?;
+                Ok(())
+            })
+            .await?;
+
             if use_external_suite {
                 // Open again and test with pjdfstest
                 open_and_mount(&volume_config, |_, mount_dir: PathBuf| async move {
@@ -320,6 +330,84 @@ pub async fn run_test_on_volume(config_str: &str, use_external_suite: bool) -> R
             })
             .await?;
         }
+    }
+
+    Ok(())
+}
+
+const PARALLEL_FS_STRESS: FsStressConfig = FsStressConfig {
+    workers: 16,
+    data_files_per_worker: 128,
+    tree_dirs_per_worker: 256,
+};
+
+struct FsStressConfig {
+    workers: usize,
+    data_files_per_worker: usize,
+    tree_dirs_per_worker: usize,
+}
+
+async fn run_fs_stress(root: &Path, config: FsStressConfig) -> anyhow::Result<()> {
+    let data = vec![0u8; 1024 * 1024];
+    let mut tasks = Vec::with_capacity(config.workers);
+    for worker in 0..config.workers {
+        let worker_dir = root.join(format!("w{worker}"));
+        let data = data.clone();
+        let data_files_per_worker = config.data_files_per_worker;
+        tasks.push(tokio::spawn(async move {
+            tokio::fs::create_dir_all(&worker_dir).await?;
+            for file in 0..data_files_per_worker {
+                tokio::fs::write(worker_dir.join(format!("f{file}")), &data).await?;
+            }
+            std::io::Result::Ok(())
+        }));
+    }
+
+    let mut stress_error = None;
+    for task in tasks {
+        match task.await {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => {
+                stress_error.get_or_insert_with(|| anyhow::Error::new(err));
+            }
+            Err(err) => {
+                stress_error.get_or_insert_with(|| anyhow::Error::new(err));
+            }
+        }
+    }
+    if let Some(err) = stress_error {
+        return Err(err);
+    }
+
+    let mut tasks = Vec::with_capacity(config.workers);
+    for worker in 0..config.workers {
+        let worker_tree = root.join("trees").join(format!("w{worker}"));
+        let tree_dirs_per_worker = config.tree_dirs_per_worker;
+        tasks.push(tokio::spawn(async move {
+            tokio::fs::create_dir_all(&worker_tree).await?;
+            for dir in 0..tree_dirs_per_worker {
+                let dir_path = worker_tree.join(format!("d{dir}"));
+                tokio::fs::create_dir_all(&dir_path).await?;
+                tokio::fs::write(dir_path.join("file"), format!("w{worker}-{dir}")).await?;
+            }
+            std::io::Result::Ok(())
+        }));
+    }
+
+    let mut stress_error = None;
+    for task in tasks {
+        match task.await {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => {
+                stress_error.get_or_insert_with(|| anyhow::Error::new(err));
+            }
+            Err(err) => {
+                stress_error.get_or_insert_with(|| anyhow::Error::new(err));
+            }
+        }
+    }
+    if let Some(err) = stress_error {
+        return Err(err);
     }
 
     Ok(())


### PR DESCRIPTION
- Add comprehensive doc comments to `IntegrityType` enum for LUKS2 integrity verification types
- Refactor mkfs command argument handling to support multiple flags via slice instead of single string
- Disable ext4 lazy initialization (lazy_itable_init=0, lazy_journal_init=0) to ensure filesystem is fully ready immediately after formatting. https://github.com/confidential-containers/guest-components/issues/1433
- Replace string-interpolation tracing with structured fields in mkfs and data migration flows
- Add trace-level logging for page migration during dummy-to-real device sync
- Fix explicit `i32` type annotation for loop device ioctl result
- Introduce parallel filesystem stress test (16 workers, 128 files and 256 dirs per worker) in volume integration tests