### PR TITLE
fix(verity): drop libfuse3 dynamic link dependency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ When creating or amending commits:
 - **Author and committer** must always be taken from the local git config (`git config user.name` / `git config user.email`). Never use Claude's own identity.
 - **Never** add `Co-Authored-By:` trailers of any kind.
 - **Never** include any Claude session URLs, session IDs, or links to claude.ai in commit messages or PR descriptions. Commit messages should only describe the code changes.
+- **Never** include `🤖 Generated with [Claude Code](https://claude.com/claude-code)` or similar AI assistant references in PR descriptions or commit messages.
 - **Always** use `--no-gpg-sign` to avoid GPG signing.
 
 ## Pre-Commit Checks
@@ -25,6 +26,19 @@ Fix any errors or warnings reported before proceeding with the commit.
 > `libdevmapper`, etc.) that may not be present in all dev environments. If they fail
 > solely due to missing system dependencies (not code errors), the CI pipeline will
 > serve as the authoritative check. `cargo fmt --check` must always pass locally.
+
+## Testing
+
+- Run `make test` in `cryptpilot-verity/` to execute the full integration test suite
+  (format, dump, verify, open/FUSE mount, tamper detection, close).
+- Run `cargo test -p verity-fuse -p verity-core` for unit tests (requires `cd verity-core && python3 make_testfiles.py` first).
+
+## FUSE Dependency
+
+The `fuser` crate in workspace `Cargo.toml` uses `default-features = false` to avoid
+linking `libfuse3.so.3`. This allows `cryptpilot-verity` to run on systems without
+libfuse3 installed, as long as `/dev/fuse` and the FUSE kernel module are available.
+The pure-Rust FUSE implementation communicates directly with the kernel via `/dev/fuse`.
 
 ## Pre-Push Checks
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1509,7 +1509,6 @@ dependencies = [
  "log",
  "memchr",
  "page_size",
- "pkg-config",
  "smallvec",
  "zerocopy 0.6.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ dialoguer = "0.11.0"
 digest = "0.10.7"
 dirs = "6.0.0"
 documented = "0.9.1"
-fuser = {version = "0.13", features = ["libfuse"]}
+fuser = {version = "0.13", default-features = false}
 futures = "0.3.31"
 futures-lite = "2.6.0"
 glob = "0.3.2"

--- a/cryptpilot-verity/README.md
+++ b/cryptpilot-verity/README.md
@@ -67,6 +67,12 @@ The CLI interface and subcommand design are intentionally similar to the `verity
    - Uses the metadata to create a `verity-fuse` filesystem.
    - Each read is verified against the Merkle tree before data is returned to the caller.
 
+## Dependencies
+
+- **`fusermount` (or `fusermount3`)**: Required for the `open` and `close` subcommands to mount/unmount the FUSE filesystem.
+- **No `libfuse3` needed**: The binary does **not** dynamically link against `libfuse3.so`. It uses a pure Rust FUSE implementation that communicates directly with the kernel via `/dev/fuse`. Only `fusermount` (the user-space mount helper) needs to be installed on the target system.
+- All other subcommands (`format`, `verify`, `dump`) have no external dependencies.
+
 ## Commands
 
 All commands are subcommands of the `cryptpilot-verity` binary. Run `cryptpilot-verity --help` or `cryptpilot-verity <subcommand> --help` for details.

--- a/cryptpilot-verity/README_zh.md
+++ b/cryptpilot-verity/README_zh.md
@@ -66,6 +66,12 @@ CLI 接口和子命令设计有意与 `veritysetup` 工具类似，以便熟悉 
    - 使用元数据创建 `verity-fuse` 文件系统。
    - 在将数据返回给调用者之前，每次读取都会根据 Merkle 树进行验证。
 
+## 依赖
+
+- **`fusermount`（或 `fusermount3`）**: `open` 和 `close` 子命令挂载/卸载 FUSE 文件系统时需要。
+- **无需 `libfuse3`**: 二进制文件**不**动态链接 `libfuse3.so`。它使用纯 Rust FUSE 实现，直接通过 `/dev/fuse` 与内核通信。目标系统上只需安装 `fusermount`（用户空间挂载辅助工具）。
+- 其余子命令（`format`、`verify`、`dump`）无任何外部依赖。
+
 ## 命令
 
 所有命令都是 `cryptpilot-verity` 二进制文件的子命令。运行 `cryptpilot-verity --help` 或 `cryptpilot-verity <subcommand> --help` 以获取详细信息。


### PR DESCRIPTION
## Summary
- Change `fuser` dependency from `features = ["libfuse"]` to `default-features = false` so `cryptpilot-verity` no longer dynamically links `libfuse3.so.3`
- The binary now uses the pure Rust FUSE implementation via `/dev/fuse` — only `fusermount` is needed at runtime for `open`/`close` subcommands
- `ldd` output confirms no `libfuse3` dependency after the change
- Add dependency notes to `README.md` and `README_zh.md`

## Test plan
- [x] `make clippy` passes
- [x] `cargo fmt --check` passes
- [x] `cargo build --release` succeeds
- [x] `make test` in `cryptpilot-verity/` passes (format, dump, verify, open, tamper detection, close)
- [x] `ldd target/release/cryptpilot-verity` shows no `libfuse3.so.3`