### PR TITLE
ci: print cryptpilot-convert diagnostic log on test failure

### DIFF
--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -281,6 +281,12 @@ jobs:
             make run-convert-test-case BOOTLOADER=${{ matrix.bootloader }} ROOTFS_ENC=${{ matrix.rootfs_enc }} DELTA_LOCATION=${{ matrix.delta_location }} INPUT_IMAGE=/workspace/test-images/test-image.qcow2 CRYPTPILOT_FDE_RPM=${{ steps.install-rpm.outputs.cryptpilot_fde_rpm_container }}
           "
 
+      - name: Print convert diagnostic log
+        if: always()
+        run: |
+          echo "=== /tmp/.cryptpilot-convert.log (from test-container) ==="
+          docker exec test-container cat /tmp/.cryptpilot-convert.log 2>/dev/null || echo "(log file not available)"
+
       - name: Cleanup
         if: always()
         run: |


### PR DESCRIPTION
## Summary
- Adds an `always()` CI step in the `test-convert` job to dump `/tmp/.cryptpilot-convert.log` from inside the test container before cleanup
- Helps diagnose intermittent `qemu-img` shared lock errors (e.g. `uki-enc-disk-persist` test failure) by surfacing the full convert log even when the test fails