### PR TITLE
fix(test): increase QEMU boot timeout from 3 to 6 minutes

### DIFF
--- a/tests/test-convert.sh
+++ b/tests/test-convert.sh
@@ -515,7 +515,7 @@ test_qemu_boot() {
     log::info "QEMU container started: ${container_name}"
 
     # Stream logs to file and check for boot status
-    local timeout=180  # 3 minutes timeout
+    local timeout=360  # 6 minutes timeout
     local elapsed=0
     local check_interval=2
     local boot_success=false


### PR DESCRIPTION
## Summary

- Increase QEMU boot test timeout from 180s to 360s in `tests/test-convert.sh`
- Fixes timeout failure in `grub-noenc-disk` test caused by slow boot without KVM acceleration in CI