### PR TITLE
fix(verity-go): correct Go module path to match GitHub repository

### DIFF
--- a/verity-go/README.md
+++ b/verity-go/README.md
@@ -30,7 +30,7 @@ compute fs-verity for each file, build the Merkle tree, and write the FlatBuffer
 metadata file:
 
 ```bash
-cargo run -p cryptpilot-verity -- format /path/to/dir --label env=prod -m metadata.fb
+cargo run -p cryptpilot-verity -- format /path/to/dir --label env=prod -m metadata.fb --hash-output -
 ```
 
 #### Option B: Go implementation

--- a/verity-go/README.md
+++ b/verity-go/README.md
@@ -30,7 +30,7 @@ compute fs-verity for each file, build the Merkle tree, and write the FlatBuffer
 metadata file:
 
 ```bash
-cargo run -p cryptpilot-verity -- format /path/to/dir --label env=prod --hash-output metadata.fb
+cargo run -p cryptpilot-verity -- format /path/to/dir --label env=prod -m metadata.fb
 ```
 
 #### Option B: Go implementation
@@ -42,7 +42,6 @@ package main
 
 import (
 	"encoding/hex"
-	"fmt"
 	"os"
 
 	"github.com/openanolis/cryptpilot/verity-go/metadata"
@@ -76,7 +75,6 @@ are available:
 package main
 
 import (
-	"encoding/hex"
 	"fmt"
 	"os"
 

--- a/verity-go/README_CN.md
+++ b/verity-go/README_CN.md
@@ -29,7 +29,7 @@ Rust `cryptpilot-verity` CLI 可自动完成完整流程 — 遍历目录、
 计算每个文件的 fs-verity、构建 Merkle 树、输出 FlatBuffers 元数据文件：
 
 ```bash
-cargo run -p cryptpilot-verity -- format /path/to/dir --label env=prod -m metadata.fb
+cargo run -p cryptpilot-verity -- format /path/to/dir --label env=prod -m metadata.fb --hash-output -
 ```
 
 #### 方式 B：Go 代码实现

--- a/verity-go/README_CN.md
+++ b/verity-go/README_CN.md
@@ -29,7 +29,7 @@ Rust `cryptpilot-verity` CLI 可自动完成完整流程 — 遍历目录、
 计算每个文件的 fs-verity、构建 Merkle 树、输出 FlatBuffers 元数据文件：
 
 ```bash
-cargo run -p cryptpilot-verity -- format /path/to/dir --label env=prod --hash-output metadata.fb
+cargo run -p cryptpilot-verity -- format /path/to/dir --label env=prod -m metadata.fb
 ```
 
 #### 方式 B：Go 代码实现
@@ -41,7 +41,6 @@ package main
 
 import (
 	"encoding/hex"
-	"fmt"
 	"os"
 
 	"github.com/openanolis/cryptpilot/verity-go/metadata"
@@ -74,7 +73,6 @@ func main() {
 package main
 
 import (
-	"encoding/hex"
 	"fmt"
 	"os"
 

--- a/verity-go/go.mod
+++ b/verity-go/go.mod
@@ -1,4 +1,4 @@
-module cryptpilot-verity-go
+module github.com/openanolis/cryptpilot/verity-go
 
 go 1.24
 

--- a/verity-go/metadata/interop_test.go
+++ b/verity-go/metadata/interop_test.go
@@ -10,7 +10,7 @@ import (
 	"runtime"
 	"testing"
 
-	"cryptpilot-verity-go/verity"
+	"github.com/openanolis/cryptpilot/verity-go/verity"
 )
 
 // expectedDescriptorHashes maps test file name to expected SHA-256 descriptor hash.

--- a/verity-go/metadata/metadata.go
+++ b/verity-go/metadata/metadata.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"sort"
 
-	"cryptpilot-verity-go/metadata/generated"
-	"cryptpilot-verity-go/verity"
+	"github.com/openanolis/cryptpilot/verity-go/metadata/generated"
+	"github.com/openanolis/cryptpilot/verity-go/verity"
 
 	flatbuffers "github.com/google/flatbuffers/go"
 )

--- a/verity-go/metadata/metadata_hash.go
+++ b/verity-go/metadata/metadata_hash.go
@@ -6,7 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	"cryptpilot-verity-go/metadata/generated"
+	"github.com/openanolis/cryptpilot/verity-go/metadata/generated"
 
 	flatbuffers "github.com/google/flatbuffers/go"
 )

--- a/verity-go/metadata/metadata_test.go
+++ b/verity-go/metadata/metadata_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"cryptpilot-verity-go/verity"
+	"github.com/openanolis/cryptpilot/verity-go/verity"
 )
 
 func makeTestFileVerityInfo(path string, data []byte) FileVerityInfo {


### PR DESCRIPTION
## Summary

- Fix `go.mod` module name from `cryptpilot-verity-go` to `github.com/openanolis/cryptpilot/verity-go`
- Update all internal import paths to match

## Why

The README told users to `go get github.com/openanolis/cryptpilot/verity-go`, but the module was declared as `cryptpilot-verity-go`, making the documented import paths fail at compile time.