### PR TITLE
ci: pass --define 'with_rustup 1' to all yum-builddep invocations

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -47,7 +47,7 @@ jobs:
         uses: dtolnay/rust-toolchain@1.85.0
 
       - name: Install build dependencies
-        run: yum-builddep -y --skip-unavailable ./cryptpilot.spec
+        run: yum-builddep -y --skip-unavailable --define 'with_rustup 1' ./cryptpilot.spec
 
       - name: Install Clippy
         run: rustup component add clippy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
           submodules: 'true'
 
       - name: Install build dependencies
-        run: yum-builddep -y --skip-unavailable ./cryptpilot.spec
+        run: yum-builddep -y --skip-unavailable --define 'with_rustup 1' ./cryptpilot.spec
 
       - name: Run test script from repo
         run: make run-test

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ rpm-build:
 
 	# install build dependencies
 	which yum-builddep || { yum install -y yum-utils ; }
-	yum-builddep -y --skip-unavailable ./cryptpilot.spec
+	yum-builddep -y --skip-unavailable --define 'with_rustup 1' ./cryptpilot.spec
 	
 	# build 
 	rpmbuild -ba ./cryptpilot.spec --define 'with_rustup 1'
@@ -95,7 +95,7 @@ rpm-build-in-al3-docker:
 	mkdir -p ~/rpmbuild/SOURCES/
 	cp /tmp/cryptpilot-${VERSION}-vendored-source.tar.gz ~/rpmbuild/SOURCES/
 
-	docker run --rm -v ~/rpmbuild:/root/rpmbuild -v .:/code --workdir=/code alibaba-cloud-linux-3-registry.cn-hangzhou.cr.aliyuncs.com/alinux3/alinux3:latest bash -x -c "sed -i -E 's|https?://mirrors.cloud.aliyuncs.com/|https://mirrors.aliyun.com/|g' /etc/yum.repos.d/*.repo ; sed -i 's/^max_parallel_downloads=.*/max_parallel_downloads=20/' /etc/yum.conf ; if ! grep -q '^max_parallel_downloads=' /etc/yum.conf; then sed -i '/^\[main\]$/a max_parallel_downloads=20' /etc/yum.conf; fi ; curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-toolchain none ; source \"\$$HOME/.cargo/env\" ; yum install -y rpmdevtools yum-utils; rpmdev-setuptree ; yum-builddep -y --skip-unavailable ./cryptpilot.spec ; rpmbuild -ba ./cryptpilot.spec --define 'with_rustup 1'"
+	docker run --rm -v ~/rpmbuild:/root/rpmbuild -v .:/code --workdir=/code alibaba-cloud-linux-3-registry.cn-hangzhou.cr.aliyuncs.com/alinux3/alinux3:latest bash -x -c "sed -i -E 's|https?://mirrors.cloud.aliyuncs.com/|https://mirrors.aliyun.com/|g' /etc/yum.repos.d/*.repo ; sed -i 's/^max_parallel_downloads=.*/max_parallel_downloads=20/' /etc/yum.conf ; if ! grep -q '^max_parallel_downloads=' /etc/yum.conf; then sed -i '/^\[main\]$/a max_parallel_downloads=20' /etc/yum.conf; fi ; curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-toolchain none ; source \"\$$HOME/.cargo/env\" ; yum install -y rpmdevtools yum-utils; rpmdev-setuptree ; yum-builddep -y --skip-unavailable --define 'with_rustup 1' ./cryptpilot.spec ; rpmbuild -ba ./cryptpilot.spec --define 'with_rustup 1'"
 
 .PHONE: rpm-build-in-an23-docker
 rpm-build-in-an23-docker:
@@ -103,7 +103,7 @@ rpm-build-in-an23-docker:
 	mkdir -p ~/rpmbuild/SOURCES/
 	cp /tmp/cryptpilot-${VERSION}-vendored-source.tar.gz ~/rpmbuild/SOURCES/
 
-	docker run --rm -v ~/rpmbuild:/root/rpmbuild -v .:/code --workdir=/code registry.openanolis.cn/openanolis/anolisos:23 bash -x -c "sed -i 's/^max_parallel_downloads=.*/max_parallel_downloads=20/' /etc/yum.conf ; if ! grep -q '^max_parallel_downloads=' /etc/yum.conf; then sed -i '/^\[main\]$/a max_parallel_downloads=20' /etc/yum.conf; fi ; curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-toolchain none ; source \"\$$HOME/.cargo/env\" ; yum install -y rpmdevtools yum-utils; rpmdev-setuptree ; yum-builddep -y --skip-unavailable ./cryptpilot.spec ; rpmbuild -ba ./cryptpilot.spec --define 'with_rustup 1'"
+	docker run --rm -v ~/rpmbuild:/root/rpmbuild -v .:/code --workdir=/code registry.openanolis.cn/openanolis/anolisos:23 bash -x -c "sed -i 's/^max_parallel_downloads=.*/max_parallel_downloads=20/' /etc/yum.conf ; if ! grep -q '^max_parallel_downloads=' /etc/yum.conf; then sed -i '/^\[main\]$/a max_parallel_downloads=20' /etc/yum.conf; fi ; curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-toolchain none ; source \"\$$HOME/.cargo/env\" ; yum install -y rpmdevtools yum-utils; rpmdev-setuptree ; yum-builddep -y --skip-unavailable --define 'with_rustup 1' ./cryptpilot.spec ; rpmbuild -ba ./cryptpilot.spec --define 'with_rustup 1'"
 
 .PHONE: rpm-build-in-docker
 rpm-build-in-docker: rpm-build-in-al3-docker
@@ -114,7 +114,7 @@ rpm-build-in-docker-aarch64:
 	mkdir -p ~/rpmbuild/SOURCES/
 	cp /tmp/cryptpilot-${VERSION}-vendored-source.tar.gz ~/rpmbuild/SOURCES/
 
-	docker run --rm --platform linux/arm64 -v ~/rpmbuild:/root/rpmbuild -v .:/code --workdir=/code alibaba-cloud-linux-3-registry.cn-hangzhou.cr.aliyuncs.com/alinux3/alinux3:latest bash -x -c "sed -i -E 's|https?://mirrors.cloud.aliyuncs.com/|https://mirrors.aliyun.com/|g' /etc/yum.repos.d/*.repo ; sed -i 's/^max_parallel_downloads=.*/max_parallel_downloads=20/' /etc/yum.conf ; if ! grep -q '^max_parallel_downloads=' /etc/yum.conf; then sed -i '/^\[main\]$/a max_parallel_downloads=20' /etc/yum.conf; fi ; curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-toolchain none ; source \"\$$HOME/.cargo/env\" ; yum install -y rpmdevtools yum-utils; rpmdev-setuptree ; yum-builddep -y --skip-unavailable ./cryptpilot.spec ; rpmbuild -ba ./cryptpilot.spec --define 'with_rustup 1'"
+	docker run --rm --platform linux/arm64 -v ~/rpmbuild:/root/rpmbuild -v .:/code --workdir=/code alibaba-cloud-linux-3-registry.cn-hangzhou.cr.aliyuncs.com/alinux3/alinux3:latest bash -x -c "sed -i -E 's|https?://mirrors.cloud.aliyuncs.com/|https://mirrors.aliyun.com/|g' /etc/yum.repos.d/*.repo ; sed -i 's/^max_parallel_downloads=.*/max_parallel_downloads=20/' /etc/yum.conf ; if ! grep -q '^max_parallel_downloads=' /etc/yum.conf; then sed -i '/^\[main\]$/a max_parallel_downloads=20' /etc/yum.conf; fi ; curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-toolchain none ; source \"\$$HOME/.cargo/env\" ; yum install -y rpmdevtools yum-utils; rpmdev-setuptree ; yum-builddep -y --skip-unavailable --define 'with_rustup 1' ./cryptpilot.spec ; rpmbuild -ba ./cryptpilot.spec --define 'with_rustup 1'"
 
 .PHONE: rpm-install
 rpm-install: rpm-build


### PR DESCRIPTION
## Summary
- Add `--define 'with_rustup 1'` to all `yum-builddep` calls in `Makefile`, `.github/workflows/test.yml`, and `.github/workflows/clippy.yml`
- Previously `yum-builddep` was invoked without this flag, causing Rust toolchain to be installed via yum despite `rpmbuild` already using `--define 'with_rustup 1'` to select rustup. This inconsistency led to redundant system Rust packages being pulled in.