### PR TITLE
fix(make): add cleanup-stale-devices target to remove orphan dm-crypt and loop devices before tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,8 +145,28 @@ deb-install: deb-build
 	dpkg -i ../cryptpilot-verity_*.deb ../cryptpilot-fde_*.deb ../cryptpilot-crypt_*.deb ../cryptpilot_*.deb
 	apt-get install -f -y
 
+.PHONY: cleanup-stale-devices
+cleanup-stale-devices:
+	@# Remove leftover dm-crypt devices from previous failed test runs
+	@# Must remove inner crypt devices first (they hold refs to _dif integrity layers)
+	@dmsetup ls --target crypt | grep '\.cryptpilot-' | awk '{print $$1}' | while read name; do \
+		echo "dmsetup remove $$name ..."; \
+		dmsetup remove "$$name" 2>/dev/null || true; \
+	done
+	@# Then remove integrity devices
+	@dmsetup ls --target integrity | grep '\.cryptpilot-' | awk '{print $$1}' | while read name; do \
+		echo "dmsetup remove $$name ..."; \
+		dmsetup remove "$$name" 2>/dev/null || true; \
+	done
+	@# Detach loop devices whose backing file was under /tmp/cryptpilot-*
+	@losetup -l 2>/dev/null | grep '/tmp/cryptpilot-' | awk '{print $$1}' | sed 's/://g' | while read dev; do \
+		echo "losetup -d $$dev ..."; \
+		losetup -d "$$dev" 2>/dev/null || true; \
+	done
+	@echo "Cleanup complete."
+
 .PHONY: run-test
-run-test: install-test-depend verity-testfiles
+run-test: cleanup-stale-devices install-test-depend verity-testfiles
 	cargo test -- --nocapture
 
 .PHONY: verity-testfiles


### PR DESCRIPTION
## Summary
- Add `make cleanup-stale-devices` target that removes leftover dm-crypt (crypt + integrity) devices and orphan loop devices from failed test runs
- Wire it as a prerequisite of `make run-test` so cleanup runs automatically before every test session
- All errors suppressed with `2>/dev/null || true` so it is safe to run when nothing needs cleaning

## Context
When integration tests fail, loop devices and their dm-crypt layers (inner crypt on top of outer _dif integrity) are left dangling. The backing temp files get deleted but the kernel devices persist, blocking subsequent test runs. The cleanup order is critical: inner crypt devices must be removed first since they hold references to the _dif integrity devices.