### PR TITLE
feat: add test coverage reporting with Codecov badge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,7 @@ jobs:
         run: make run-test-coverage
 
       - name: Upload coverage to Codecov
+        if: matrix.arch == 'x86_64' && contains(matrix.distro, 'alinux3')
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,15 @@ jobs:
         include:
           - arch: x86_64
             runner: ubuntu-latest
+            # x86_64 does not need the profiler builtins workaround
+            rust_version: "1.85.0"
           - arch: aarch64
             runner: ubuntu-24.04-arm
+            # aarch64 requires Rust >= 1.86.0 for cargo-llvm-cov:
+            # Rust 1.85.0 libprofiler_builtins on aarch64 references
+            # __aarch64_cas8_sync / __aarch64_ldadd8_sync atomic builtins
+            # that are not linked by gcc. Fixed in Rust 1.86.0.
+            rust_version: "1.86.0"
     runs-on: ${{ matrix.runner }}
     defaults:
       run:
@@ -60,7 +67,7 @@ jobs:
           yum install -y device-mapper kmod systemd systemd-udev lvm2 util-linux veritysetup dosfstools xfsprogs e2fsprogs fuse3 fuse3-libs
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.85.0
+        uses: dtolnay/rust-toolchain@${{ matrix.rust_version }}
 
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,8 +70,15 @@ jobs:
       - name: Install build dependencies
         run: yum-builddep -y --skip-unavailable --define 'with_rustup 1' ./cryptpilot.spec
 
-      - name: Run test script from repo
-        run: make run-test
+      - name: Run tests with coverage
+        run: make run-test-coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: target/codecov.json
+          fail_ci_if_error: false
 
   go-test:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -178,6 +178,7 @@ install-cargo-llvm-cov:
 		echo "Installing cargo-llvm-cov..."; \
 		rustup component add llvm-tools; \
 		HOST=$$(rustc -vV | grep '^host:' | cut -d' ' -f2); \
+		mkdir -p $$HOME/.cargo/bin; \
 		curl -fsSL "https://github.com/taiki-e/cargo-llvm-cov/releases/download/v0.6.16/cargo-llvm-cov-$${HOST}.tar.gz" | tar xzf - -C $$HOME/.cargo/bin; \
 		echo "cargo-llvm-cov installed"; \
 	fi
@@ -185,7 +186,7 @@ install-cargo-llvm-cov:
 .PHONY: run-test-coverage
 run-test-coverage: cleanup-stale-devices install-test-depend verity-testfiles install-cargo-llvm-cov
 	cargo llvm-cov clean --workspace
-	cargo llvm-cov --no-report --workspace --bins --lib -- --nocapture
+	cargo llvm-cov --no-report --workspace --all-targets -- --nocapture
 	cargo llvm-cov report --codecov --output-path target/codecov.json
 	@echo "Coverage report generated at target/codecov.json"
 

--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,26 @@ cleanup-stale-devices:
 run-test: cleanup-stale-devices install-test-depend verity-testfiles
 	cargo test -- --nocapture
 
+# cargo-llvm-cov v0.6.16 (pinned 2026-06-12, update as needed)
+.PHONY: install-cargo-llvm-cov
+install-cargo-llvm-cov:
+	@if command -v cargo-llvm-cov >/dev/null 2>&1; then \
+		echo "cargo-llvm-cov is already installed"; \
+	else \
+		echo "Installing cargo-llvm-cov..."; \
+		rustup component add llvm-tools; \
+		HOST=$$(rustc -vV | grep '^host:' | cut -d' ' -f2); \
+		curl -fsSL "https://github.com/taiki-e/cargo-llvm-cov/releases/download/v0.6.16/cargo-llvm-cov-$${HOST}.tar.gz" | tar xzf - -C $$HOME/.cargo/bin; \
+		echo "cargo-llvm-cov installed"; \
+	fi
+
+.PHONY: run-test-coverage
+run-test-coverage: cleanup-stale-devices install-test-depend verity-testfiles install-cargo-llvm-cov
+	cargo llvm-cov clean --workspace
+	cargo llvm-cov --no-report --workspace --bins --lib -- --nocapture
+	cargo llvm-cov report --codecov --output-path target/codecov.json
+	@echo "Coverage report generated at target/codecov.json"
+
 .PHONY: verity-testfiles
 verity-testfiles:
 	@cd verity-core && python3 make_testfiles.py

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Building](/../../actions/workflows/build-rpm.yml/badge.svg)](/../../actions/workflows/build-rpm.yml)
 ![GitHub Release](https://img.shields.io/github/v/release/openanolis/cryptpilot)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![codecov](https://codecov.io/gh/openanolis/cryptpilot/branch/master/graph/badge.svg)](https://codecov.io/gh/openanolis/cryptpilot)
 
 cryptpilot provides comprehensive encryption solutions for confidential computing environments, protecting both system boot integrity and data at rest.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -3,6 +3,7 @@
 [![Building](/../../actions/workflows/build-rpm.yml/badge.svg)](/../../actions/workflows/build-rpm.yml)
 ![GitHub Release](https://img.shields.io/github/v/release/openanolis/cryptpilot)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![codecov](https://codecov.io/gh/openanolis/cryptpilot/branch/master/graph/badge.svg)](https://codecov.io/gh/openanolis/cryptpilot)
 
 cryptpilot 为机密计算环境提供全面的加密解决方案，保护系统启动完整性和静态数据。
 


### PR DESCRIPTION
## Summary

- Add `make run-test-coverage` target using `cargo-llvm-cov` to collect Rust test coverage and generate Codecov-compatible JSON report
- Update CI workflow (`.github/workflows/test.yml`) to run coverage tests and upload to Codecov
- Add Codecov badge to `README.md` and `README_zh.md`

## Changes

| File | Change |
|------|--------|
| `Makefile` | Add `install-cargo-llvm-cov` and `run-test-coverage` targets |
| `.github/workflows/test.yml` | Replace `make run-test` with `make run-test-coverage`, add `codecov/codecov-action@v5` upload step |
| `README.md` | Add Codecov badge |
| `README_zh.md` | Add Codecov badge |

## Notes

- Requires `CODECOV_TOKEN` GitHub secret (configure at https://app.codecov.io)
- `fail_ci_if_error: false` ensures CI still passes if token is not yet configured
- Coverage scope: `--all-targets` matches existing `cargo test` behavior (lib + bins + tests)

## Test Plan

- [x] `cargo fmt --check` passes
- [x] `make -n run-test-coverage` produces correct commands
- [x] `make run-test-coverage` successfully generates `target/codecov.json` (verified locally)
- [x] YAML syntax validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)