### PR TITLE
feat(provider/kms): add ECS RAM role authentication support

### DIFF
--- a/cryptpilot-core/src/provider/kms.rs
+++ b/cryptpilot-core/src/provider/kms.rs
@@ -12,7 +12,7 @@ use crate::types::Passphrase;
 use super::KeyProvider;
 
 /// Aliyun KMS
-#[derive(Deserialize, Serialize, Debug, PartialEq, Clone, Documented)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Clone, Documented, DocumentedFields)]
 #[serde(deny_unknown_fields)]
 pub struct KmsConfig {
     /// The id of KMS instance

--- a/cryptpilot-core/src/provider/kms.rs
+++ b/cryptpilot-core/src/provider/kms.rs
@@ -5,26 +5,208 @@ use anyhow::{Context, Result};
 use base64::{prelude::BASE64_STANDARD, Engine as _};
 use documented::{Documented, DocumentedFields};
 use kms::{plugins::aliyun::AliyunKmsClient, Annotations, Getter as _};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::types::Passphrase;
 
 use super::KeyProvider;
 
 /// Aliyun KMS
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Documented, DocumentedFields)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Clone, Documented)]
 #[serde(deny_unknown_fields)]
 pub struct KmsConfig {
     /// The id of KMS instance
     pub kms_instance_id: String,
     /// The name of the secret store in the KMS instance.
     pub secret_name: String,
-    /// Content of the clientKey_****.json file.
-    pub client_key: String,
-    /// Content of the clientKey_****_Password.txt file.
-    pub client_key_password: String,
-    /// The CA cert of the KMS (the content of PrivateKmsCA_kst-******.pem file).
-    pub kms_cert_pem: String,
+    /// Authentication credentials (flattened into the same TOML table)
+    #[serde(flatten, deserialize_with = "deserialize_auth_mode")]
+    pub auth: AuthMode,
+}
+
+/// Authentication mode for Aliyun KMS
+#[derive(Serialize, Debug, PartialEq, Clone, DocumentedFields)]
+pub enum AuthMode {
+    /// Client Key (application access point) authentication.
+    /// Requires a pre-generated client_key JSON file and password.
+    ClientKey {
+        /// Content of the clientKey_****.json file.
+        client_key: String,
+        /// Content of the clientKey_****_Password.txt file.
+        client_key_password: String,
+        /// The CA cert of the KMS (the content of PrivateKmsCA_kst-******.pem file).
+        kms_cert_pem: String,
+    },
+    /// ECS RAM Role authentication.
+    /// The ECS instance must have a RAM role bound. Temporary STS credentials
+    /// are fetched from the instance metadata service (IMDS) automatically.
+    EcsRamRole {
+        /// ECS RAM role name. Optional — if not set, discovered from IMDS.
+        /// When the instance has exactly one RAM role bound, it is auto-detected.
+        /// When multiple roles are bound, this field must be specified explicitly.
+        ecs_ram_role_name: Option<String>,
+        /// Region ID (e.g. "cn-shanghai"). Optional — auto-discovered from IMDS if not set.
+        region_id: Option<String>,
+    },
+}
+
+/// Intermediate deserialization helper — all fields optional
+#[derive(Deserialize)]
+struct AuthModeDeHelper {
+    auth_mode: Option<String>,
+    client_key: Option<String>,
+    client_key_password: Option<String>,
+    kms_cert_pem: Option<String>,
+    ecs_ram_role_name: Option<String>,
+    region_id: Option<String>,
+}
+
+/// Custom deserializer for AuthMode with backward compatibility:
+/// - `auth_mode = "ecs_ram_role"` → EcsRamRole
+/// - otherwise (including missing `auth_mode`) → ClientKey
+fn deserialize_auth_mode<'de, D>(deserializer: D) -> Result<AuthMode, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::de::Error;
+
+    let helper = AuthModeDeHelper::deserialize(deserializer)?;
+
+    match helper.auth_mode.as_deref() {
+        Some("ecs_ram_role") => Ok(AuthMode::EcsRamRole {
+            ecs_ram_role_name: helper.ecs_ram_role_name,
+            region_id: helper.region_id,
+        }),
+        _ => Ok(AuthMode::ClientKey {
+            client_key: helper
+                .client_key
+                .ok_or_else(|| Error::custom("missing field `client_key`"))?,
+            client_key_password: helper
+                .client_key_password
+                .ok_or_else(|| Error::custom("missing field `client_key_password`"))?,
+            kms_cert_pem: helper
+                .kms_cert_pem
+                .ok_or_else(|| Error::custom("missing field `kms_cert_pem`"))?,
+        }),
+    }
+}
+
+impl KmsConfig {
+    /// Create a new KmsConfig with ClientKey authentication
+    #[allow(dead_code)]
+    pub fn new_client_key(
+        kms_instance_id: String,
+        secret_name: String,
+        client_key: String,
+        client_key_password: String,
+        kms_cert_pem: String,
+    ) -> Self {
+        Self {
+            kms_instance_id,
+            secret_name,
+            auth: AuthMode::ClientKey {
+                client_key,
+                client_key_password,
+                kms_cert_pem,
+            },
+        }
+    }
+
+    /// Create a new KmsConfig with ECS RAM Role authentication
+    #[allow(dead_code)]
+    pub fn new_ecs_ram_role(
+        kms_instance_id: String,
+        secret_name: String,
+        ecs_ram_role_name: Option<String>,
+        region_id: Option<String>,
+    ) -> Self {
+        Self {
+            kms_instance_id,
+            secret_name,
+            auth: AuthMode::EcsRamRole {
+                ecs_ram_role_name,
+                region_id,
+            },
+        }
+    }
+}
+
+/// IMDS metadata endpoint base URL
+const IMDS_BASE: &str = "http://100.100.100.200/latest/meta-data";
+
+/// Discover the region ID from IMDS
+async fn discover_region() -> Result<String> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .context("Failed to create HTTP client for IMDS")?;
+
+    let region_id = client
+        .get(format!("{IMDS_BASE}/region-id"))
+        .send()
+        .await
+        .context("Failed to request region ID from IMDS")?
+        .text()
+        .await
+        .context("Failed to read region ID from IMDS response")?;
+
+    let region_id = region_id.trim().to_string();
+    if region_id.is_empty() {
+        anyhow::bail!("IMDS returned an empty region ID");
+    }
+
+    tracing::info!("Auto-discovered region ID: {}", region_id);
+    Ok(region_id)
+}
+
+/// Discover the ECS RAM role name from IMDS
+async fn discover_ram_role_name() -> Result<String> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .context("Failed to create HTTP client for IMDS")?;
+
+    let resp = client
+        .get(format!("{IMDS_BASE}/ram/security-credentials/"))
+        .send()
+        .await
+        .context("Failed to request RAM role list from IMDS")?;
+
+    if resp.status() == reqwest::StatusCode::NOT_FOUND {
+        anyhow::bail!(
+            "No RAM role bound to this ECS instance (IMDS returned 404). \
+             Bind a RAM role or specify `ecs_ram_role_name` in the config."
+        );
+    }
+
+    let body = resp
+        .text()
+        .await
+        .context("Failed to read RAM role list from IMDS response")?;
+
+    let roles: Vec<&str> = body
+        .lines()
+        .map(|l| l.trim())
+        .filter(|l| !l.is_empty())
+        .collect();
+
+    match roles.len() {
+        0 => anyhow::bail!(
+            "IMDS returned an empty RAM role list. \
+             Bind a RAM role to this ECS instance or specify `ecs_ram_role_name` in the config."
+        ),
+        1 => {
+            let role_name = roles[0].to_string();
+            tracing::info!("Auto-discovered RAM role name: {}", role_name);
+            Ok(role_name)
+        }
+        _ => anyhow::bail!(
+            "Multiple RAM roles bound to this ECS instance ({} found: {:?}). \
+             Please specify `ecs_ram_role_name` explicitly in the config.",
+            roles.len(),
+            roles
+        ),
+    }
 }
 
 pub struct KmsKeyProvider {
@@ -32,16 +214,38 @@ pub struct KmsKeyProvider {
 }
 
 impl KmsKeyProvider {
-    #[allow(unused)]
     async fn get_key_from_kms(&self) -> Result<Vec<u8>> {
-        let kms_client = AliyunKmsClient::new_client_key_client(
-            &self.options.client_key,
-            &self.options.kms_instance_id,
-            &self.options.client_key_password,
-            &self.options.kms_cert_pem,
-        )?;
+        let kms_client = match &self.options.auth {
+            AuthMode::ClientKey {
+                client_key,
+                client_key_password,
+                kms_cert_pem,
+            } => AliyunKmsClient::new_client_key_client(
+                client_key,
+                &self.options.kms_instance_id,
+                client_key_password,
+                kms_cert_pem,
+            )
+            .context("Failed to create Aliyun KMS client from client key")?,
 
-        // to get resource using a get_resource_provider client we do not need the Annotations.
+            AuthMode::EcsRamRole {
+                ecs_ram_role_name,
+                region_id,
+            } => {
+                let region_id = match region_id {
+                    Some(r) => r.clone(),
+                    None => discover_region().await?,
+                };
+
+                let ecs_ram_role_name = match ecs_ram_role_name {
+                    Some(n) => n.clone(),
+                    None => discover_ram_role_name().await?,
+                };
+
+                AliyunKmsClient::new_ecs_ram_role_client(&ecs_ram_role_name, &region_id)
+            }
+        };
+
         let max_attempts = 5;
 
         RetryPolicy::fixed(Duration::from_secs(1))
@@ -61,12 +265,24 @@ impl KmsKeyProvider {
 #[async_trait::async_trait]
 impl KeyProvider for KmsKeyProvider {
     fn debug_name(&self) -> String {
-        format!("KMS (key ID: {}) via Access Key", self.options.secret_name)
+        match &self.options.auth {
+            AuthMode::ClientKey { .. } => {
+                format!("KMS (key ID: {}) via Client Key", self.options.secret_name)
+            }
+            AuthMode::EcsRamRole {
+                ecs_ram_role_name, ..
+            } => {
+                let role = ecs_ram_role_name.as_deref().unwrap_or("(auto-discovered)");
+                format!(
+                    "KMS (key ID: {}) via ECS RAM Role ({})",
+                    self.options.secret_name, role
+                )
+            }
+        }
     }
 
     async fn get_key(&self) -> Result<Passphrase> {
         let key_u8 = if cfg!(test) || std::env::var("CRYPTPILOT_TEST_MODE").is_ok() {
-            // In test mode, return mock data
             BASE64_STANDARD.encode(b"test").into_bytes()
         } else {
             self.get_key_from_kms().await?
@@ -80,10 +296,99 @@ impl KeyProvider for KmsKeyProvider {
         .context("Failed to decode response from KMS as base64")?;
 
         tracing::info!("The passphrase has been fetched from KMS");
-        return Ok(passphrase);
+        Ok(passphrase)
     }
 
     fn volume_type(&self) -> super::VolumeType {
         super::VolumeType::Persistent
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_client_key_config_deserialize() {
+        let toml = r#"
+            kms_instance_id = "kst-test123"
+            secret_name = "test-secret"
+            client_key = '{"KeyId":"KAAP.test","PrivateKeyData":"test"}'
+            client_key_password = "testpass"
+            kms_cert_pem = "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----\n"
+        "#;
+        let config: KmsConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.kms_instance_id, "kst-test123");
+        assert_eq!(config.secret_name, "test-secret");
+        match &config.auth {
+            AuthMode::ClientKey {
+                client_key,
+                client_key_password,
+                kms_cert_pem,
+            } => {
+                assert!(client_key.contains("KAAP.test"));
+                assert_eq!(client_key_password, "testpass");
+                assert!(kms_cert_pem.contains("BEGIN CERTIFICATE"));
+            }
+            AuthMode::EcsRamRole { .. } => panic!("Expected ClientKey auth mode"),
+        }
+    }
+
+    #[test]
+    fn test_ecs_ram_role_config_deserialize() {
+        let toml = r#"
+            auth_mode = "ecs_ram_role"
+            kms_instance_id = "kst-test123"
+            secret_name = "test-secret"
+            ecs_ram_role_name = "MyRamRole"
+            region_id = "cn-shanghai"
+        "#;
+        let config: KmsConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.kms_instance_id, "kst-test123");
+        assert_eq!(config.secret_name, "test-secret");
+        match &config.auth {
+            AuthMode::EcsRamRole {
+                ecs_ram_role_name,
+                region_id,
+            } => {
+                assert_eq!(ecs_ram_role_name.as_deref(), Some("MyRamRole"));
+                assert_eq!(region_id.as_deref(), Some("cn-shanghai"));
+            }
+            AuthMode::ClientKey { .. } => panic!("Expected EcsRamRole auth mode"),
+        }
+    }
+
+    #[test]
+    fn test_ecs_ram_role_config_deserialize_minimal() {
+        let toml = r#"
+            auth_mode = "ecs_ram_role"
+            kms_instance_id = "kst-test123"
+            secret_name = "test-secret"
+        "#;
+        let config: KmsConfig = toml::from_str(toml).unwrap();
+        match &config.auth {
+            AuthMode::EcsRamRole {
+                ecs_ram_role_name,
+                region_id,
+            } => {
+                assert!(ecs_ram_role_name.is_none());
+                assert!(region_id.is_none());
+            }
+            _ => panic!("Expected EcsRamRole auth mode"),
+        }
+    }
+
+    #[test]
+    fn test_client_key_config_missing_client_key_fails() {
+        let toml = r#"
+            kms_instance_id = "kst-test123"
+            secret_name = "test-secret"
+            client_key_password = "testpass"
+            kms_cert_pem = "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----\n"
+        "#;
+        let result: Result<KmsConfig, _> = toml::from_str(toml);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("client_key"));
     }
 }

--- a/cryptpilot-core/src/provider/kms.rs
+++ b/cryptpilot-core/src/provider/kms.rs
@@ -134,6 +134,10 @@ impl KmsConfig {
 /// IMDS metadata endpoint base URL
 const IMDS_BASE: &str = "http://100.100.100.200/latest/meta-data";
 
+// TODO: Support IMDSv2 for instances that enforce token-only metadata access.
+// IMDSv2 requires: PUT http://100.100.100.200/latest/api/token with
+// X-aliyun-ecs-metadata-token-ttl-seconds header, then use the token in
+// subsequent GET requests via X-aliyun-ecs-metadata-token header.
 /// Discover the region ID from IMDS
 async fn discover_region() -> Result<String> {
     let client = reqwest::Client::builder()
@@ -141,11 +145,20 @@ async fn discover_region() -> Result<String> {
         .build()
         .context("Failed to create HTTP client for IMDS")?;
 
-    let region_id = client
+    let resp = client
         .get(format!("{IMDS_BASE}/region-id"))
         .send()
         .await
-        .context("Failed to request region ID from IMDS")?
+        .context("Failed to request region ID from IMDS")?;
+
+    if resp.status() == reqwest::StatusCode::NOT_FOUND {
+        anyhow::bail!(
+            "IMDS region endpoint not reachable. \
+             This may not be running on Alibaba Cloud ECS."
+        );
+    }
+
+    let region_id = resp
         .text()
         .await
         .context("Failed to read region ID from IMDS response")?;

--- a/cryptpilot-crypt/docs/key-providers.md
+++ b/cryptpilot-crypt/docs/key-providers.md
@@ -74,23 +74,62 @@ Template: [kbs.toml.template](../../dist/etc/volumes/kbs.toml.template)
 
 ---
 
-### KMS: Key Management Service (Access Key)
+### KMS: Key Management Service
 
-Fetches keys from [Alibaba Cloud KMS](https://yundun.console.aliyun.com/) using Access Key authentication.
+Fetches keys from [Alibaba Cloud KMS](https://yundun.console.aliyun.com/).
 
-**Configuration:**
+Two authentication modes are supported:
+
+#### Mode 1: Client Key (Application Access Point) — Default
+
+Uses a pre-generated client key for authentication.
 
 ```toml
 [encrypt.kms]
 kms_instance_id = "kst-****"
-client_key_id = "LTAI****"
-client_key_password_from_kms = "alias/ClientKey_****"
+secret_name = "my-secret"
+client_key = '{"KeyId":"KAAP.****","PrivateKeyData":"****"}'
+client_key_password = "****"
+kms_cert_pem = """
+-----BEGIN CERTIFICATE-----
+...
+-----END CERTIFICATE-----
+"""
 ```
+
+#### Mode 2: ECS RAM Role — No Static Credentials
+
+Bind a RAM role to your ECS instance. cryptpilot automatically discovers the region and role name from the instance metadata service (IMDS).
+
+**Minimal configuration (auto-discover everything):**
+
+```toml
+[encrypt.kms]
+auth_mode = "ecs_ram_role"
+kms_instance_id = "kst-****"
+secret_name = "my-secret"
+# ecs_ram_role_name and region_id are auto-discovered from IMDS
+```
+
+**Explicit configuration:**
+
+```toml
+[encrypt.kms]
+auth_mode = "ecs_ram_role"
+kms_instance_id = "kst-****"
+secret_name = "my-secret"
+ecs_ram_role_name = "MyKmsRamRole"
+region_id = "cn-shanghai"
+```
+
+> [!NOTE]
+> Auto-discovery of `ecs_ram_role_name` requires the ECS instance to have exactly one RAM role bound. If multiple roles are bound, you must specify `ecs_ram_role_name` explicitly.
 
 **Use cases:**
 - Cloud-managed key lifecycle
 - Centralized key management
 - Integration with Alibaba Cloud services
+- Zero static credentials on instances (RAM role mode)
 
 **Supported by:** cryptpilot-fde, cryptpilot-crypt
 

--- a/cryptpilot-crypt/docs/key-providers_zh.md
+++ b/cryptpilot-crypt/docs/key-providers_zh.md
@@ -74,23 +74,62 @@ key_uri = "kbs:///default/mykey/volume_data0"
 
 ---
 
-### KMS：密钥管理服务（Access Key）
+### KMS：密钥管理服务
 
-从[阿里云密钥管理服务 KMS](https://yundun.console.aliyun.com/) 获取密钥，使用 Access Key 进行身份验证。
+从[阿里云密钥管理服务 KMS](https://yundun.console.aliyun.com/) 获取密钥。
 
-**配置：**
+支持两种认证模式：
+
+#### 模式一：Client Key（应用接入点）— 默认
+
+使用预生成的 Client Key 进行认证。
 
 ```toml
 [encrypt.kms]
 kms_instance_id = "kst-****"
-client_key_id = "LTAI****"
-client_key_password_from_kms = "alias/ClientKey_****"
+secret_name = "my-secret"
+client_key = '{"KeyId":"KAAP.****","PrivateKeyData":"****"}'
+client_key_password = "****"
+kms_cert_pem = """
+-----BEGIN CERTIFICATE-----
+...
+-----END CERTIFICATE-----
+"""
 ```
+
+#### 模式二：ECS RAM 角色 — 无静态凭证
+
+为 ECS 实例绑定 RAM 角色。cryptpilot 自动从实例元数据服务（IMDS）发现区域和角色名称。
+
+**最简配置（全自动发现）：**
+
+```toml
+[encrypt.kms]
+auth_mode = "ecs_ram_role"
+kms_instance_id = "kst-****"
+secret_name = "my-secret"
+# ecs_ram_role_name 和 region_id 从 IMDS 自动发现
+```
+
+**显式配置：**
+
+```toml
+[encrypt.kms]
+auth_mode = "ecs_ram_role"
+kms_instance_id = "kst-****"
+secret_name = "my-secret"
+ecs_ram_role_name = "MyKmsRamRole"
+region_id = "cn-shanghai"
+```
+
+> [!NOTE]
+> 自动发现 `ecs_ram_role_name` 要求 ECS 实例仅绑定一个 RAM 角色。如果绑定了多个角色，必须显式指定 `ecs_ram_role_name`。
 
 **使用场景：**
 - 云托管的密钥生命周期
 - 集中式密钥管理
 - 与阿里云服务集成
+- 实例上无静态凭证（RAM 角色模式）
 
 **支持范围：** cryptpilot-fde, cryptpilot-crypt
 

--- a/cryptpilot-crypt/src/bin/gen-template/main.rs
+++ b/cryptpilot-crypt/src/bin/gen-template/main.rs
@@ -77,22 +77,22 @@ impl VolumeType {
     pub fn get_volume_config(self) -> VolumeConfig {
         let key_provider = match self {
             VolumeType::Otp => KeyProviderConfig::Otp(OtpConfig {}),
-            VolumeType::Kms => KeyProviderConfig::Kms(KmsConfig {
-                secret_name: "XXXXXXXXX".into(),
-                client_key: r#"{
+            VolumeType::Kms => KeyProviderConfig::Kms(KmsConfig::new_client_key(
+                "kst-XXXXXXXXX".into(),
+                "XXXXXXXXX".into(),
+                r#"{
   "KeyId": "KAAP.XXXXXXXXX",
   "PrivateKeyData": "XXXXXXXXX"
 }"#
                 .into(),
-                client_key_password: "XXXXXXXXX".into(),
-                kms_instance_id: "kst-XXXXXXXXX".into(),
-                kms_cert_pem: r#"-----BEGIN CERTIFICATE-----
+                "XXXXXXXXX".into(),
+                r#"-----BEGIN CERTIFICATE-----
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 -----END CERTIFICATE-----
 "#
                 .into(),
-            }),
+            )),
             VolumeType::Kbs => KeyProviderConfig::Kbs(KbsConfig {
                 cdh_type: CdhType::OneShot {
                     kbs_url: "https://1.2.3.4:8080".into(),

--- a/cryptpilot-crypt/src/config/volume.rs
+++ b/cryptpilot-crypt/src/config/volume.rs
@@ -162,14 +162,16 @@ nc8BTncWI0KGWIzTQasuSEye50R6gc9wZCGIElmhWcu3NYk=
             },
             encrypt: EncryptConfig {
                 key_provider: KeyProviderConfig::Kms(cryptpilot::provider::kms::KmsConfig {
-                    client_key: r#"{
+                    kms_instance_id: "kst-bjj66bdba95w1m0xfm3bt".to_owned(),
+                    secret_name: "luks_passphrase".to_owned(),
+                    auth: cryptpilot::provider::kms::AuthMode::ClientKey {
+                        client_key: r#"{
   "KeyId": "KAAP.f4c8****",
   "PrivateKeyData": "MIIJ****"
 }"#
-                    .to_owned(),
-                    client_key_password: "fa79****".to_owned(),
-                    kms_instance_id: "kst-bjj66bdba95w1m0xfm3bt".to_owned(),
-                    kms_cert_pem: r#"-----BEGIN CERTIFICATE-----
+                        .to_owned(),
+                        client_key_password: "fa79****".to_owned(),
+                        kms_cert_pem: r#"-----BEGIN CERTIFICATE-----
 MIIDuzCCAqOgAwIBAgIJALTKwWAjvbMiMA0GCSqGSIb3DQEBCwUAMHQxCzAJBgNV
 BAYTAkNOMREwDwYDVQQIDAhaaGVKaWFuZzERMA8GA1UEBwwISGFuZ1pob3UxEDAO
 BgNVBAoMB0FsaWJhYmExDzANBgNVBAsMBkFsaXl1bjEcMBoGA1UEAwwTUHJpdmF0
@@ -215,8 +217,8 @@ PpVsaCU9401qPWRWftXJgb3vIVOsYB6l3KYYKdOpudaCzSbZVROmC4a693/E5hWM
 nc8BTncWI0KGWIzTQasuSEye50R6gc9wZCGIElmhWcu3NYk=
 -----END CERTIFICATE-----
 "#
-                    .to_owned(),
-                    secret_name: "luks_passphrase".to_owned(),
+                        .to_owned(),
+                    },
                 }),
             },
         };


### PR DESCRIPTION
## Summary

Add ECS RAM role authentication to the KMS key provider, allowing users to bind a RAM role to their ECS instance and obtain KMS credentials automatically via IMDS — no static ClientKey needed.

## Changes

### Core Implementation
- **cryptpilot-core/src/provider/kms.rs**: Restructure `KmsConfig` to use a tagged `AuthMode` enum (`ClientKey` | `EcsRamRole`) with backward-compatible deserialization. Add IMDS auto-discovery for `region_id` and `ecs_ram_role_name`.

### Configuration
- **New auth mode**: `auth_mode = "ecs_ram_role"` in `[encrypt.kms]`
- **Auto-discovery**: When `ecs_ram_role_name` or `region_id` not specified, automatically discover from ECS instance metadata service
- **Backward compatible**: Existing configs without `auth_mode` continue to work as ClientKey mode

### Template & Documentation
- Update `gen-template` to use new constructor
- Update `key-providers.md` and `key-providers_zh.md` with new auth mode documentation

### Bug Fixes
- Fix `KmsConfig` struct literal in `volume.rs` test (broke after refactor)
- Add `DocumentedFields` derive on `KmsConfig` (regression from initial refactor)
- Add explicit HTTP error handling in IMDS discovery functions
- Add IMDSv2 TODO note for future hardening

## New Configuration Example

```toml
[encrypt.kms]
auth_mode = "ecs_ram_role"
kms_instance_id = "kst-****"
secret_name = "my-secret"
# ecs_ram_role_name and region_id are auto-discovered from IMDS
```

## Testing

- 4 new unit tests for config deserialization (ClientKey backward compat, EcsRamRole explicit, EcsRamRole minimal, validation)
- `cargo fmt --check`: PASS
- `cargo clippy`: PASS (no warnings)
- All existing tests compile and pass
