### PR TITLE
fix(convert): support GCP-style images with a separate ESP grub.cfg and vendor kernels

### DIFF
--- a/cryptpilot-convert.sh
+++ b/cryptpilot-convert.sh
@@ -443,9 +443,14 @@ install_zram_module_if_needed() {
     if [ -x "${rootfs_mount_point}/usr/bin/apt-get" ] && [ -x "${rootfs_mount_point}/usr/bin/dpkg" ]; then
         log::info "Detecting Ubuntu-like system, attempting to install zram kernel modules"
 
-        # Find the kernel version from the currently installed kernel image
+        # Find the kernel version from the installed kernel image. Pick the
+        # highest-versioned vmlinuz regardless of flavor (e.g. -generic, -gcp, -aws)
+        # so cloud-vendor kernels are handled too; this matches the kernel selected
+        # for the initrd later (ls /boot/vmlinuz-* | sort -V | tail -1). The previous
+        # hard-coded "-generic" match returned empty on vendor-kernel-only images and
+        # aborted with "Could not determine kernel version".
         local kernel_version
-        kernel_version=$(chroot "${rootfs_mount_point}" bash -c "dpkg -l | grep -oP 'linux-image-\K[0-9.-]+-generic' | head -n1")
+        kernel_version=$(chroot "${rootfs_mount_point}" bash -c "ls /boot/vmlinuz-* 2>/dev/null | sed 's#.*/vmlinuz-##' | grep -v rescue | sort -V | tail -n1")
 
         if [ -z "$kernel_version" ]; then
             log::error "Could not determine kernel version, zram module installation failed"
@@ -995,6 +1000,33 @@ if [ "${uki:-false}" = false ]; then
             echo "Running update-grub"
             update-grub || true
         fi
+    fi
+
+    # Some images keep a *separate*, full grub.cfg on the EFI System Partition that
+    # the firmware reads directly (e.g. GCP Ubuntu cloud images read
+    # /boot/efi/EFI/<distro>/grub.cfg, while the steps above only refreshed the
+    # boot-partition copy at /boot/grub/grub.cfg). On such layouts a kernel or
+    # cmdline change here never reaches the partition the firmware boots from, so it
+    # boots a stale (often already-removed) kernel and fails with
+    # "vmlinuz-... not found" / "*.mod not found". Propagate the regenerated
+    # grub.cfg and grub module directory to each such ESP copy. No-op when there is
+    # no separate ESP grub.cfg, or when grub-mkconfig already wrote straight to the
+    # ESP (e.g. the alinux symlink case, detected via -ef).
+    if [ -n "${grub2_cfg:-}" ] && [ -f "$grub2_cfg" ] && [ -d /boot/efi/EFI ]; then
+        boot_grub_dir=$(dirname "$grub2_cfg")
+        for esp_grub_cfg in /boot/efi/EFI/*/grub.cfg; do
+            [ -f "$esp_grub_cfg" ] || continue
+            [ "$grub2_cfg" -ef "$esp_grub_cfg" ] && continue
+            echo "Syncing regenerated grub.cfg to ESP: $esp_grub_cfg"
+            cp -f "$grub2_cfg" "$esp_grub_cfg"
+            esp_grub_dir=$(dirname "$esp_grub_cfg")
+            for moddir in x86_64-efi arm64-efi i386-efi; do
+                if [ -d "$boot_grub_dir/$moddir" ]; then
+                    rm -rf "$esp_grub_dir/$moddir"
+                    cp -a "$boot_grub_dir/$moddir" "$esp_grub_dir/$moddir"
+                fi
+            done
+        done
     fi
     echo "Cleaning up package manager cache..."
     if command -v yum >/dev/null 2>&1; then


### PR DESCRIPTION
## Problem

`cryptpilot-convert` cannot produce a bootable image from a GCP Ubuntu 24.04 cloud image. Two independent issues:

1. **Stale ESP `grub.cfg`.** GCP images keep a full, firmware-read `grub.cfg` on the EFI System Partition (`/boot/efi/EFI/<distro>/grub.cfg`), while convert only regenerates the boot-partition copy (`/boot/grub/grub.cfg`). After conversion the ESP copy still references the pre-conversion kernel, so the firmware boots a stale (often already-removed) kernel and the boot fails with `error: file '/vmlinuz-...' not found` / `error: file '/EFI/ubuntu/x86_64-efi/bli.mod' not found`.

2. **zram module detection hard-codes `-generic`.** `install_zram_module_if_needed` greps `dpkg -l` for `linux-image-...-generic`. On an image whose only kernel is a cloud-vendor flavor (e.g. `-gcp`, `-aws`), the match is empty and convert aborts with `Could not determine kernel version`.

## Fix

1. After regenerating the boot-partition `grub.cfg`, propagate it (and the grub module directory, e.g. `x86_64-efi`) to each *separate* ESP `grub.cfg`. No-op when there is no separate ESP copy; skips the case where `grub-mkconfig` already wrote straight to the ESP (e.g. the alinux symlink), detected with `-ef`.
2. Select the highest-versioned installed `vmlinuz` regardless of flavor, matching the kernel already chosen for the initrd later (`ls /boot/vmlinuz-* | sort -V | tail -1`).

Both changes are scoped to behavior that was already broken for these images and are no-ops on layouts that already worked (e.g. alinux UEFI, single-grub.cfg images).

## Testing

End-to-end on a GCP Ubuntu 24.04 image converted with a `6.17.0-1018-gcp` kernel, with the equivalent out-of-tree post-processing removed so convert alone is exercised:

- convert logs `Syncing regenerated grub.cfg to ESP: /boot/efi/EFI/ubuntu/grub.cfg`; the ESP `grub.cfg` default entry now points at the `-gcp` kernel and the `x86_64-efi` module dir (incl. `bli.mod`) is present.
- zram detection resolves `6.17.0-1018-gcp` instead of aborting.
- The converted image boots successfully both under QEMU/OVMF and on a real GCP TDX Confidential VM: `cryptpilot-fde` before-sysroot sets up dm-verity + zram + dm-snapshot, `/sysroot` mounts, after-sysroot completes, switch-root succeeds, and the system reaches multi-user.
